### PR TITLE
Seperate registry for LLVM and CUDA backends

### DIFF
--- a/include/enoki/array_traits.h
+++ b/include/enoki/array_traits.h
@@ -286,6 +286,23 @@ template <typename T> using plain_t = typename detail::plain<T>::type;
 template <typename T>
 using struct_support_t = typename struct_support<std::decay_t<T>>::type;
 
+namespace detail {
+    template <typename T, typename = int> struct backend {
+        static constexpr JitBackend value = (JitBackend) 0u;
+    };
+
+    template <typename T> struct backend<T, enable_if_cuda_array_t<T>> {
+        static constexpr JitBackend value = JitBackend::CUDA;
+    };
+
+    template <typename T> struct backend<T, enable_if_llvm_array_t<T>> {
+        static constexpr JitBackend value = JitBackend::LLVM;
+    };
+}
+
+/// Determine the backend of an Enoki array (scalars evaluate to 0)
+template <typename T> constexpr JitBackend backend_v = detail::backend<T>::value;
+
 //! @}
 // -----------------------------------------------------------------------
 

--- a/include/enoki/jit.h
+++ b/include/enoki/jit.h
@@ -90,7 +90,7 @@ struct JitArray : ArrayBase<Value_, is_mask_v<Value_>, Derived_> {
         if constexpr (!IsClass)
             av = (ActualValue) value;
         else
-            av = jit_registry_get_id(value);
+            av = jit_registry_get_id(Backend, value);
 
         m_index = jit_var_new_literal(Backend, Type, &av);
     }
@@ -103,7 +103,7 @@ struct JitArray : ArrayBase<Value_, is_mask_v<Value_>, Derived_> {
             m_index = jit_var_mem_copy(Backend, AllocType::Host, Type, data,
                                        sizeof...(Ts));
         } else {
-            uint32_t data[] = { jit_registry_get_id(ts)... };
+            uint32_t data[] = { jit_registry_get_id(Backend, ts)... };
             m_index = jit_var_mem_copy(Backend, AllocType::Host, Type, data,
                                        sizeof...(Ts));
         }
@@ -454,7 +454,7 @@ struct JitArray : ArrayBase<Value_, is_mask_v<Value_>, Derived_> {
         } else {
             uint32_t *temp = new uint32_t[size];
             for (uint32_t i = 0; i < size; i++)
-                temp[i] = jit_registry_get_id(((const void **) ptr)[i]);
+                temp[i] = jit_registry_get_id(Backend, ((const void **) ptr)[i]);
             Derived result = steal(
                 jit_var_mem_copy(Backend, AllocType::Host, Type, temp, (uint32_t) size));
             delete[] temp;
@@ -471,7 +471,8 @@ struct JitArray : ArrayBase<Value_, is_mask_v<Value_>, Derived_> {
             uint32_t *temp = new uint32_t[size];
             jit_memcpy(Backend, temp, data(), size * sizeof(uint32_t));
             for (uint32_t i = 0; i < size; i++)
-                ((void **) ptr)[i] = jit_registry_get_ptr(CallSupport::Domain, temp[i]);
+                ((void **) ptr)[i] =
+                    jit_registry_get_ptr(Backend, CallSupport::Domain, temp[i]);
             delete[] temp;
         }
     }
@@ -603,7 +604,7 @@ struct JitArray : ArrayBase<Value_, is_mask_v<Value_>, Derived_> {
         if constexpr (!IsClass)
             return out;
         else
-            return (Value) jit_registry_get_ptr(CallSupport::Domain, out);
+            return (Value) jit_registry_get_ptr(Backend, CallSupport::Domain, out);
     }
 
     void set_entry(size_t offset, Value value) {
@@ -611,7 +612,7 @@ struct JitArray : ArrayBase<Value_, is_mask_v<Value_>, Derived_> {
         if constexpr (!IsClass) {
             index = jit_var_write(m_index, offset, &value);
         } else {
-            ActualValue av = jit_registry_get_id(value);
+            ActualValue av = jit_registry_get_id(Backend, value);
             index = jit_var_write(m_index, (uint32_t) offset, &av);
         }
         jit_var_dec_ref_ext(m_index);

--- a/include/enoki/vcall.h
+++ b/include/enoki/vcall.h
@@ -140,10 +140,10 @@ void set_attr(Class *self, const char *name, const Value &value) {
 
 NAMESPACE_END(enoki)
 
-#define ENOKI_VCALL_REGISTER_IF(Backend_, Class, Cond)                         \
+#define ENOKI_VCALL_REGISTER(Array, Class)                                     \
     static constexpr const char *Domain = #Class;                              \
-    static constexpr bool Registered = Cond;                                   \
-    static constexpr JitBackend Backend = Backend_;                            \
+    static constexpr bool Registered = enoki::is_jit_array_v<Array>;           \
+    static constexpr JitBackend Backend = enoki::backend_v<Array>;             \
     void *operator new(size_t size) {                                          \
         void *ptr = ::operator new(size);                                      \
         if constexpr (Registered)                                              \
@@ -166,9 +166,6 @@ NAMESPACE_END(enoki)
             jit_registry_remove(Backend, ptr);                                 \
         ::operator delete(ptr, align);                                         \
     }
-
-#define ENOKI_VCALL_REGISTER(Backend, Class)                                   \
-    ENOKI_VCALL_REGISTER_IF(Backend, Class, true)
 
 #define ENOKI_VCALL_METHOD(name)                                               \
     template <typename... Args> auto name(const Args &... args_) const {       \

--- a/tests/vcall.cpp
+++ b/tests/vcall.cpp
@@ -41,7 +41,7 @@ struct Base {
     }
 
     float field() const { return 1.2f; };
-    ENOKI_VCALL_REGISTER(Float::Backend, Base)
+    ENOKI_VCALL_REGISTER(Float, Base)
 
 protected:
     Float x;
@@ -191,7 +191,7 @@ struct BaseD {
     void dummy() { }
     virtual StructFD f(const StructFD &m) = 0;
     virtual StructFD g(const StructFD &m) = 0;
-    ENOKI_VCALL_REGISTER(Float::Backend, BaseD)
+    ENOKI_VCALL_REGISTER(FloatD, BaseD)
     FloatD x;
 };
 

--- a/tests/vcall.cpp
+++ b/tests/vcall.cpp
@@ -41,7 +41,7 @@ struct Base {
     }
 
     float field() const { return 1.2f; };
-    ENOKI_VCALL_REGISTER(Base)
+    ENOKI_VCALL_REGISTER(Float::Backend, Base)
 
 protected:
     Float x;
@@ -191,7 +191,7 @@ struct BaseD {
     void dummy() { }
     virtual StructFD f(const StructFD &m) = 0;
     virtual StructFD g(const StructFD &m) = 0;
-    ENOKI_VCALL_REGISTER(BaseD)
+    ENOKI_VCALL_REGISTER(Float::Backend, BaseD)
     FloatD x;
 };
 


### PR DESCRIPTION
This PR seperated the pointer registry datastructures for the LLVM and CUDA backends.