### PR TITLE
Opaque slice op

### DIFF
--- a/enoki/generic.py
+++ b/enoki/generic.py
@@ -1389,16 +1389,8 @@ def full_(cls, value, size):
 @classmethod
 def opaque_(cls, value, size):
     result = cls()
-    if cls.Size == Dynamic:
-        result.init_(size)
-        for i in range(size):
-            result.set_entry_(i, value)
-    else:
-        if _ek.array_depth_v(value) != cls.Depth - 1:
-            value = _ek.opaque(cls.Value, value, size)
-
-        for i in range(cls.Size):
-            result.set_entry_(i, value)
+    for i in range(cls.Size):
+        result.set_entry_(i, _ek.opaque(cls.Value, value.entry_(i), size))
     return result
 
 @classmethod

--- a/enoki/router.py
+++ b/enoki/router.py
@@ -2303,13 +2303,21 @@ def full(type_, value, size=1):
     else:
         return type_(value)
 
-def opaque(type_, value, size=1):
+
+def opaque(type_, value, size=-1):
     if not isinstance(type_, type):
         raise Exception('opaque(): Type expected as first argument')
-    elif issubclass(type_, ArrayBase):
+    value = type_(value)
+    if issubclass(type_, ArrayBase):
         return type_.opaque_(value, size)
+    elif _ek.is_enoki_struct_v(type_):
+        result = type_()
+        for k, v in type_.ENOKI_STRUCT.items():
+            setattr(result, k, opaque(v, getattr(value, k), size))
+        return result
     else:
         return type_(value)
+
 
 def linspace(type_, min, max, size=1, endpoint=True):
     if not isinstance(type_, type):

--- a/enoki/router.py
+++ b/enoki/router.py
@@ -636,6 +636,27 @@ def unravel(target_class, array):
     indices = arange(_ek.uint32_array_t(type(array)), len(array) // size)
     return gather(target_class, array, indices)
 
+
+def slice(value, index=-1):
+    if index == -1:
+        if _ek.width(value) > 1:
+            raise Exception('slice(): variable contains more than a single entry!')
+        index = 0
+    t = type(value)
+    if _ek.array_depth_v(t) > 1 or issubclass(t, tuple) or issubclass(t, list):
+        size = len(value)
+        result = [None] * size
+        for i in range(size):
+            result[i] = slice(value[i], index)
+        return result
+    elif issubclass(type(value), ArrayBase):
+        return value.entry_(index)
+    elif _ek.is_enoki_struct_v(a):
+        raise Exception('slice(): structs not supported!')
+    else:
+        return value
+
+
 # -------------------------------------------------------------------
 #                        Vertical operations
 # -------------------------------------------------------------------

--- a/include/enoki/array_router.h
+++ b/include/enoki/array_router.h
@@ -1190,27 +1190,37 @@ decltype(auto) migrate(const T &value, TargetType target) {
     }
 }
 
-template <typename T>
-decltype(auto) slice(const T &value, size_t index = -1) {
-    if (index == (size_t) -1) {
-        if(width(value) > 1)
-            enoki_raise("slice(): variable contains more than a single entry!");
-        index = 0;
-    }
+template <typename ResultType = void, typename T>
+decltype(auto) get_slice(const T &value, size_t index = -1) {
     if constexpr (array_depth_v<T> > 1) {
-        using Value = decltype(slice(value.entry(0), index));
+        using Value = std::decay_t<decltype(get_slice(value.entry(0), index))>;
         using Result = typename T::template ReplaceValue<Value>;
         Result result;
         if (Result::Size == Dynamic)
             result = empty<Result>(value.size());
         for (size_t i = 0; i < value.size(); ++i)
-            result.set_entry(i, slice(value.entry(i), index));
+            result.set_entry(i, get_slice(value.entry(i), index));
         return result;
-    } else if constexpr (is_array_v<T>) {
-        return value.entry(index);
     } else if constexpr (is_enoki_struct_v<T>) {
-        enoki_raise("slice(): structs are not supported!");
+        static_assert(!std::is_same_v<ResultType, void>,
+                      "get_slice(): return type should be specified for enoki struct!");
+        ResultType result;
+        struct_support_t<T>::apply_2(
+            value, result,
+            [index](auto const &x1, auto &x2) ENOKI_INLINE_LAMBDA {
+                x2 = get_slice(x1, index);
+            });
+        return result;
+    } else if constexpr (is_dynamic_array_v<T>) {
+        if (index == (size_t) -1) {
+            if(width(value) > 1)
+                enoki_raise("get_slice(): variable contains more than a single entry!");
+            index = 0;
+        }
+        return value.entry(index);
     } else {
+        if (index != (size_t) -1 && index > 0)
+            enoki_raise("get_slice(): index out of bound!");
         return value;
     }
 }

--- a/include/enoki/array_static.h
+++ b/include/enoki/array_static.h
@@ -132,19 +132,11 @@ struct StaticArrayBase : ArrayBase<Value_, IsMask_, Derived_> {
         }
     }
 
-    template <typename T>
-    static Derived opaque_(const T &value, size_t size) {
-        if constexpr (array_depth_v<T> > array_depth_v<Value> ||
-                      (array_depth_v<T> == array_depth_v<Value> &&
-                       (is_dynamic_array_v<Value> || !is_array_v<Value>))) {
-            ENOKI_MARK_USED(size);
-            return value;
-        } else {
-            Derived result;
-            for (size_t i = 0; i < Derived::Size; ++i)
-                result.entry(i) = opaque<Value>(value, size);
-            return result;
-        }
+    static Derived opaque_(const Derived &value, size_t size) {
+        Derived result;
+        for (size_t i = 0; i < value.size(); ++i)
+            result.entry(i) = opaque(value.entry(i), size);
+        return result;
     }
 
     template <typename T = Derived>

--- a/include/enoki/autodiff.h
+++ b/include/enoki/autodiff.h
@@ -1523,8 +1523,8 @@ struct DiffArray : ArrayBase<value_t<Type_>, is_mask_v<Type_>, DiffArray<Type_>>
         return full<Type>(value, size);
     }
 
-    static DiffArray opaque_(Value value, size_t size) {
-        return opaque<Type>(value, size);
+    static DiffArray opaque_(DiffArray value, size_t size) {
+        return opaque(detach(value), size);
     }
 
     static DiffArray arange_(ssize_t start, ssize_t stop, ssize_t step) {

--- a/include/enoki/dynamic.h
+++ b/include/enoki/dynamic.h
@@ -170,8 +170,20 @@ struct DynamicArray
         return result;
     }
 
-    static DynamicArray opaque_(const Value &v, size_t size) {
-        return full_(v, size);
+    static DynamicArray opaque_(const DynamicArray &v, size_t size) {
+        if constexpr (!is_array_v<Value>) {
+            if (size == (size_t) -1 || v.size() == size)
+                return v;
+            else if (v.size() == 1)
+                return full_(v.entry(0), size);
+            else
+                enoki_raise("opaque(): value doesn't have the right size.");
+        } else {
+            DynamicArray result = DynamicArray::empty_(v.size());
+            for (size_t i = 0; i < v.size(); ++i)
+                result.entry(i) = opaque(v.entry(i), size);
+            return result;
+        }
     }
 
     static DynamicArray arange_(ssize_t start, ssize_t stop, ssize_t step) {

--- a/include/enoki/jit.h
+++ b/include/enoki/jit.h
@@ -424,9 +424,13 @@ struct JitArray : ArrayBase<Value_, is_mask_v<Value_>, Derived_> {
             jit_var_new_literal(Backend, Type, &value, size, false));
     }
 
-    static Derived opaque_(const Value &value, size_t size = 1) {
-        return steal(
-            jit_var_new_literal(Backend, Type, &value, size, true));
+    static Derived opaque_(const Derived &value, size_t size) {
+        Derived result = value;
+        if (size != (size_t) -1 && value.size() != size)
+            result.resize(size);
+        // Variable must be fully evaluated to be accessible via a pointer
+        result.data();
+        return result;
     }
 
     static Derived arange_(ssize_t start, ssize_t stop, ssize_t step) {

--- a/src/python/bind.h
+++ b/src/python/bind.h
@@ -159,7 +159,7 @@ auto bind_full(py::class_<Array> &cls, bool scalar_mode = false) {
     cls.attr("full_") = py::cpp_function(
         [](Scalar v, size_t size) { return ek::full<Array>(v, size); });
     cls.attr("opaque_") = py::cpp_function(
-        [](Scalar v, size_t size) { return ek::opaque<Array>(v, size); });
+        [](Array v, int size) { return ek::opaque(v, (size_t) size); });
 
     if constexpr (!Array::IsMask) {
         cls.attr("arange_") = py::cpp_function(&Array::arange_);

--- a/tests/python/test_basics.py
+++ b/tests/python/test_basics.py
@@ -532,3 +532,21 @@ def test17_opaque():
         assert ek.width(v) == 10
         assert ek.allclose(v, value)
 
+
+def test18_slice():
+    Float   = get_class('enoki.llvm.Float')
+    Array2f = get_class('enoki.llvm.Array2f')
+
+    a = ek.arange(Float, 10)
+    for i in range(10):
+        assert ek.slice(a, i) == i
+
+    a2 = Array2f(a, a * 10)
+    for i in range(10):
+        assert ek.slice(a2, i)[0] == i
+        assert ek.slice(a2, i)[1] == i * 10
+
+    a3 = (a, a * 10)
+    for i in range(10):
+        assert ek.slice(a3, i)[0] == i
+        assert ek.slice(a3, i)[1] == i * 10

--- a/tests/python/test_basics.py
+++ b/tests/python/test_basics.py
@@ -510,3 +510,25 @@ def test16_custom(cname):
     v5 = ek.gather(t, v4, index)
     ek.eval(v5)
     assert v5.state == v1.state and v5.inc == v1.inc
+
+
+def test17_opaque():
+    Float         = get_class('enoki.llvm.Float')
+    Array3f       = get_class('enoki.llvm.Array3f')
+    ScalarArray3f = get_class('enoki.scalar.Array3f')
+
+    values = (4.0, ScalarArray3f(3.0, 2.0, 4.0), Array3f(3.0, 2.0, 4.0))
+
+    for value in values:
+        v = ek.opaque(Array3f, value)
+        assert ek.width(v) == 1
+        assert ek.allclose(v, value)
+
+        v = ek.opaque(Array3f, value, 1)
+        assert ek.width(v) == 1
+        assert ek.allclose(v, value)
+
+        v = ek.opaque(Array3f, value, 10)
+        assert ek.width(v) == 10
+        assert ek.allclose(v, value)
+

--- a/tests/struct.cpp
+++ b/tests/struct.cpp
@@ -79,3 +79,14 @@ ENOKI_TEST(test03_scatter_gather) {
     assert(c1.d.y() == Float64X(3, 4, 2, 0, 0));
     assert(c1.o.x() == FloatX(0, 0, 1, 0, 0));
 }
+
+ENOKI_TEST(test04_slice) {
+    Custom3fX c = zero<Custom3fX>(5);
+    c.o.x() = linspace<FloatX>(0, 1, 5);
+    c.i = arange<Int32X>(5);
+
+    Custom3f c3 = get_slice<Custom3f>(c, 3);
+
+    assert(c3.o.x() == 0.75f);
+    assert(c3.i == 3);
+}


### PR DESCRIPTION
This PR is about:

- [x] improving the `ek::opaque` routine to make it compatible with static array and struct input values.
- [x] evaluate literal array with `array = ek::opaque(array)`
- [x] re-implement the `ek::slice` routine to access slices of various data structures (similar to what we had in the previous version of enoki). The default `index=-1` argument will check that the given data structure as a width of 1.
- [x] implement basic unit tests