### PR TITLE
Gimbal Lock in Quaternion -> Euler angles conversion

### DIFF
--- a/include/enoki/quaternion.h
+++ b/include/enoki/quaternion.h
@@ -233,28 +233,41 @@ template <typename Value>
 Array<Value, 3> quat_to_euler(const Quaternion<Value> &q) {
     // https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
 
-    Value q_y_2 = sqr(q.y());
+    Value sinp = 2 * fmsub(q.w(), q.y(), q.z() * q.x());
+    Mask gimbal_lock = abs(sinp) > (1.0f - 5e-8);
 
+    // roll (x-axis rotation)
+    Value q_y_2 = sqr(q.y());
     Value sinr_cosp = 2 * fmadd(q.w(), q.x(), q.y() * q.z());
     Value cosr_cosp = fnmadd(2, fmadd(q.x(), q.x(), q_y_2), 1);
-    Value roll = atan2(sinr_cosp, cosr_cosp);
+    Value roll = select(gimbal_lock, 2.0f * atan2(q.x(), q.w()), atan2(sinr_cosp, cosr_cosp));
 
     // pitch (y-axis rotation)
-    Value sinp = 2 * fmsub(q.w(), q.y(), q.z() * q.x());
-    Value pitch;
-    if (abs(sinp) >= 1)
-        pitch = copysign(0.5f * Pi<Value>, sinp); // use 90 degrees if out of range
-    else
-        pitch = asin(sinp);
+    Value pitch = select(gimbal_lock, copysign(0.5f * Pi<Value>, sinp), asin(sinp));
 
     // yaw (z-axis rotation)
     Value siny_cosp = 2 * fmadd(q.w(), q.z(), q.x() * q.y());
     Value cosy_cosp = fnmadd(2, fmadd(q.z(), q.z(), q_y_2), 1);
-    Value yaw = atan2(siny_cosp, cosy_cosp);
+    Value yaw = select(gimbal_lock, 0.f, atan2(siny_cosp, cosy_cosp));
 
     return Array<Value, 3>(roll, pitch, yaw);
 }
 
+template <typename Value>
+Quaternion<Value> euler_to_quat(const Array<Value, 3> &a) {
+    // https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+
+    Array<Value, 3> angles = a / 2.0f;
+    auto [sr, cr] = sincos(angles.x);
+    auto [sp, cp] = sincos(angles.y);
+    auto [sy, cy] = sincos(angles.z);
+
+    Value w = cr*cp*cy + sr*sp*sy;
+    Value x = sr*cp*cy - cr*sp*sy;
+    Value y = cr*sp*cy + sr*cp*sy;
+    Value z = cr*cp*sy - sr*sp*cy;
+    return Quaternion<Value>(x, y, z, w);
+}
 
 template <typename Value>
 Quaternion<Value> slerp(const Quaternion<Value> &q0,


### PR DESCRIPTION
This PR introduces a fix to the quaternion to Euler angles conversion code to handle gimbal lock properly. A unit test (on the python side) has also been added, with conversion values determined in Matlab.

The reverse conversion Euler -> Quaternion has also been implemented.