### PR TITLE
compress: do not leak memory for zero-sized result

### DIFF
--- a/include/enoki/jit.h
+++ b/include/enoki/jit.h
@@ -570,8 +570,13 @@ struct JitArray : ArrayBase<Value_, is_mask_v<Value_>, Derived_> {
             eval_();
             uint32_t size_out = jit_compress(Backend, (const uint8_t *) data(),
                                              size_in, indices);
-            return int32_array_t<Derived>::steal(
-                jit_var_mem_map(Backend, VarType::UInt32, indices, size_out, 1));
+            if (size_out > 0) {
+                return int32_array_t<Derived>::steal(
+                    jit_var_mem_map(Backend, VarType::UInt32, indices, size_out, 1));
+            } else {
+                jit_free(indices);
+                return int32_array_t<Derived>();
+            }
         }
     }
 


### PR DESCRIPTION
Not sure if this is the correct way to fix this issue, but `ek::compress` will leak memory if the input mask is fully `false`.

In that case, the following early returns triggers:

https://github.com/mitsuba-renderer/enoki-jit/blob/af18bf8d2177a911861c7e1fa2725eeacfd3e6ba/src/var.cpp#L480-L484

and so the memory allocated for `indices` never gets stolen, which means it's leaked when returning from `compress_()`:

https://github.com/wjakob/enoki/blob/2ab5258cba3143fed5e55ccff831d406ae98f5f4/include/enoki/jit.h#L571-L574