### PR TITLE
Tensor: fix accidental migrations due to `hasattr()`

### DIFF
--- a/src/python/tensor.h
+++ b/src/python/tensor.h
@@ -17,8 +17,8 @@ template <typename T> auto bind_tensor(py::module m) {
                 strncmp(mod_s, "torch", 5) == 0 ||
                 strncmp(mod_s, "jaxlib", 6) == 0 ||
                 strncmp(mod_s, "tensorflow", 10) == 0 ||
-                (py::hasattr(o, "__array_interface__") &&
-                 strncmp(mod_s, "enoki", 5) != 0)) {
+                (strncmp(mod_s, "enoki", 5) != 0
+                 && py::hasattr(o, "__array_interface__"))) {
                 o = tensor_init(py::type::of<Tensor>(), o);
                 return py::cast<Tensor>(o);
             } else {


### PR DESCRIPTION
The Tensor constructor from a Python object checks whether that object makes available an `__array_interface__` with `hasattr()`.

But `hasattr()` actually *executes* the `__array_interface__` property in order to determine whether it is available (https://stackoverflow.com/a/30143990/3792942)

If the Python object was an Enoki array, in many cases, `__array_interface__` actually needs to migrate the array to the host to make its data available.
This lead to many accidental migrations to host memory when constructing tensors from other Enoki arrays.

Ideally, we could find a way to allow `hasattr` while avoiding actual migrations, but in the meantime this fix simply avoids the `hasattr` call for Enoki arrays.