### PR TITLE
Texture: add clamp and mirror wrapping modes

### DIFF
--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -223,8 +223,7 @@ public:
             return { Value::steal(out[0]), Value::steal(out[1]),
                      Value::steal(out[2]), Value::steal(out[3]) };
         } else {
-            (void) pos;
-            (void) active;
+            (void) pos; (void) active;
             return 0;
         }
     }
@@ -465,7 +464,8 @@ public:
         auto compute_weight_coord = [&](uint32_t dim) -> Array3 {
             const Value integ = (Value) pos_i[dim];
             const Value alpha = pos_a[dim];
-            Value alpha2 = sqr(alpha), alpha3 = alpha2 * alpha;
+            Value alpha2 = sqr(alpha),
+                  alpha3 = alpha2 * alpha;
             Value multiplier = 1.f / 6.f;
             // four basis functions, transformed to take as input the fractional part
             Value w0 =
@@ -498,15 +498,18 @@ public:
                    f1 = eval_helper(PosF(cx[2]), active);
             result = lerp(f1, f0, cx[0]);
         } else if constexpr (Dimension == 2) {
-            Array3 cx = compute_weight_coord(0), cy = compute_weight_coord(1);
+            Array3 cx = compute_weight_coord(0),
+                   cy = compute_weight_coord(1);
             Array4 f00 = eval_helper(PosF(cx[1], cy[1]), active),
                    f01 = eval_helper(PosF(cx[1], cy[2]), active),
                    f10 = eval_helper(PosF(cx[2], cy[1]), active),
                    f11 = eval_helper(PosF(cx[2], cy[2]), active);
-            Array4 f0 = lerp(f01, f00, cy[0]), f1 = lerp(f11, f10, cy[0]);
+            Array4 f0 = lerp(f01, f00, cy[0]),
+                   f1 = lerp(f11, f10, cy[0]);
             result = lerp(f1, f0, cx[0]);
         } else if constexpr (Dimension == 3) {
-            Array3 cx = compute_weight_coord(0), cy = compute_weight_coord(1),
+            Array3 cx = compute_weight_coord(0),
+                   cy = compute_weight_coord(1),
                    cz = compute_weight_coord(2);
             Array4 f000 = eval_helper(PosF(cx[1], cy[1], cz[1]), active),
                    f001 = eval_helper(PosF(cx[1], cy[1], cz[2]), active),
@@ -516,9 +519,12 @@ public:
                    f101 = eval_helper(PosF(cx[2], cy[1], cz[2]), active),
                    f110 = eval_helper(PosF(cx[2], cy[2], cz[1]), active),
                    f111 = eval_helper(PosF(cx[2], cy[2], cz[2]), active);
-            Array4 f00 = lerp(f001, f000, cz[0]), f01 = lerp(f011, f010, cz[0]),
-                   f10 = lerp(f101, f100, cz[0]), f11 = lerp(f111, f110, cz[0]);
-            Array4 f0 = lerp(f01, f00, cy[0]), f1 = lerp(f11, f10, cy[0]);
+            Array4 f00 = lerp(f001, f000, cz[0]),
+                   f01 = lerp(f011, f010, cz[0]),
+                   f10 = lerp(f101, f100, cz[0]),
+                   f11 = lerp(f111, f110, cz[0]);
+            Array4 f0 = lerp(f01, f00, cy[0]),
+                   f1 = lerp(f11, f10, cy[0]);
             result = lerp(f1, f0, cx[0]);
         }
 
@@ -581,18 +587,18 @@ public:
 
         const uint32_t channels = (uint32_t) m_value.shape(Dimension);
 
-        #define EK_TEX_CUBIC_GATHER(index)                                             \
-            {                                                                          \
-                UInt32 index_ = index;                                                 \
-                for (uint32_t ch = 0; ch < channels; ++ch)                             \
-                    values[ch] = gather<Value>(m_value.array(), index_ + ch, active);  \
+        #define EK_TEX_CUBIC_GATHER(index)                                            \
+            {                                                                         \
+                UInt32 index_ = index;                                                \
+                for (uint32_t ch = 0; ch < channels; ++ch)                            \
+                    values[ch] = gather<Value>(m_value.array(), index_ + ch, active); \
             }
-        #define EK_TEX_CUBIC_ACCUM(dim, weight)                                        \
-            {                                                                          \
-                uint32_t dim_ = dim;                                                   \
-                Value weight_ = weight;                                                \
-                for (uint32_t ch = 0; ch < channels; ++ch)                             \
-                    result[dim_][ch] = fmadd(values[ch], weight_, result[dim_][ch]);   \
+        #define EK_TEX_CUBIC_ACCUM(dim, weight)                                      \
+            {                                                                        \
+                uint32_t dim_ = dim;                                                 \
+                Value weight_ = weight;                                              \
+                for (uint32_t ch = 0; ch < channels; ++ch)                           \
+                    result[dim_][ch] = fmadd(values[ch], weight_, result[dim_][ch]); \
             }
 
         std::array<Array4, Dimension> result;
@@ -607,8 +613,10 @@ public:
                 EK_TEX_CUBIC_ACCUM(0, gx[ix]);
             }
         } else if constexpr (Dimension == 2) {
-            Array4 wx = compute_weight(0, false), wy = compute_weight(1, false),
-                   gx = compute_weight(0, true), gy = compute_weight(1, true);
+            Array4 wx = compute_weight(0, false),
+                   wy = compute_weight(1, false),
+                   gx = compute_weight(0, true),
+                   gy = compute_weight(1, true);
             for (uint32_t ix = 0; ix < 4; ++ix)
                 for (uint32_t iy = 0; iy < 4; ++iy) {
                     EK_TEX_CUBIC_GATHER(idx[ix * 4 + iy]);
@@ -616,9 +624,12 @@ public:
                     EK_TEX_CUBIC_ACCUM(1, wx[ix] * gy[iy]);
                 }
         } else if constexpr (Dimension == 3) {
-            Array4 wx = compute_weight(0, false), wy = compute_weight(1, false),
-                   wz = compute_weight(2, false), gx = compute_weight(0, true),
-                   gy = compute_weight(1, true), gz = compute_weight(2, true);
+            Array4 wx = compute_weight(0, false),
+                   wy = compute_weight(1, false),
+                   wz = compute_weight(2, false),
+                   gx = compute_weight(0, true),
+                   gy = compute_weight(1, true),
+                   gz = compute_weight(2, true);
             for (uint32_t ix = 0; ix < 4; ++ix)
                 for (uint32_t iy = 0; iy < 4; ++iy)
                     for (uint32_t iz = 0; iz < 4; ++iz) {

--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -264,7 +264,7 @@ public:
             const PosF pos_f = fmadd(pos, PosF(m_shape_opaque), -.5f);
             const PosI pos_i = floor2int<PosI>(pos_f);
 
-            int offset[2] = { 0, 1 };
+            int32_t offset[2] = { 0, 1 };
 
             InterpPosI pos_i_w = interp_positions<PosI, 2>(offset, pos_i);
             pos_i_w = wrap(pos_i_w);

--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -376,7 +376,7 @@ public:
             const Value &alpha = pos_a[dim];
             Value alpha2 = alpha * alpha,
                   alpha3 = alpha2 * alpha;
-            Value multiplier = rcp(6.f);
+            Value multiplier = 1.f / 6.f;
             return multiplier *
                    Array4(-alpha3 + 3.f * alpha2 - 3.f * alpha + 1.f,
                            3.f * alpha3 - 6.f * alpha2 + 4.f,
@@ -777,12 +777,12 @@ private:
         if constexpr (Dimension == 1)
             index = Index(pos.x());
         else if constexpr (Dimension == 2)
-            index =
-                Index(fmadd(pos.y(), (Int32) m_shape_opaque.x(), pos.x()));
-        else if constexpr (Dimension == 3)
             index = Index(
-                fmadd(fmadd(pos.z(), (Int32) m_shape_opaque.y(), pos.y()),
-                      (Int32) m_shape_opaque.x(), pos.x()));
+                fmadd(Index(pos.y()), m_shape_opaque.x(), Index(pos.x())));
+        else if constexpr (Dimension == 3)
+            index = Index(fmadd(
+                fmadd(Index(pos.z()), m_shape_opaque.y(), Index(pos.y())),
+                m_shape_opaque.x(), Index(pos.x())));
 
         const uint32_t channels = (uint32_t) m_value.shape(Dimension);
 

--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -767,9 +767,9 @@ private:
         using Scalar = scalar_t<T>;
         using Index = uint32_array_t<value_t<T>>;
         static_assert(
-                array_size_v<T> == Dimension &&
-                std::is_integral_v<Scalar> &&
-                std::is_signed_v<Scalar>
+            array_size_v<T> == Dimension &&
+            std::is_integral_v<Scalar> &&
+            std::is_signed_v<Scalar>
         );
 
         Index index;

--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -535,7 +535,7 @@ public:
         return result;
     }
 
-    /// Evaluate the positional gradient of clamped cubic B-Spline from the
+    /// Evaluate the positional gradient of a clamped cubic B-Spline from the
     /// explicit differentiated basis functions
     std::array<Array<Value, 4>, Dimension>
     eval_cubic_grad(const Array<Value, Dimension> &pos,

--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -229,7 +229,6 @@ public:
         }
     }
 
-
     /**
      * \brief Evaluate linear interpolant using explicit arithmetic
      *

--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -204,8 +204,7 @@ public:
             return { Value::steal(out[0]), Value::steal(out[1]),
                      Value::steal(out[2]), Value::steal(out[3]) };
         } else {
-            (void) pos;
-            (void) active;
+            (void) pos; (void) active;
             return 0;
         }
     }
@@ -389,11 +388,7 @@ public:
 
         // `offset[k]` controls the k-th offset for any dimension.
         // With cubic B-Spline, it is by default [-1, 0, 1, 2].
-        Array4 offset;
-        offset[0] = -1;
-        offset[1] = 0;
-        offset[2] = 1;
-        offset[3] = 2;
+        Array4 offset(-1, 0, 1, 2);
 
         InterpPosI pos_i_w(0);
         if constexpr (Dimension == 1) {
@@ -448,14 +443,14 @@ public:
         const uint32_t channels = (uint32_t) m_value.shape(Dimension);
         index *= channels;
 
-        #define EK_TEX_CUBIC_ACCUM(index, weight)                                      \
-            {                                                                          \
-                UInt32 index_ = index;                                                 \
-                Value weight_ = weight;                                                \
-                for (uint32_t ch = 0; ch < channels; ++ch)                             \
-                    result[ch] =                                                       \
-                        fmadd(gather<Value>(m_value.array(), index_ + ch, active),     \
-                              weight_, result[ch]);                                    \
+        #define EK_TEX_CUBIC_ACCUM(index, weight)                                  \
+            {                                                                      \
+                UInt32 index_ = index;                                             \
+                Value weight_ = weight;                                            \
+                for (uint32_t ch = 0; ch < channels; ++ch)                         \
+                    result[ch] =                                                   \
+                        fmadd(gather<Value>(m_value.array(), index_ + ch, active), \
+                              weight_, result[ch]);                                \
             }
 
         Array4 result(0);
@@ -528,18 +523,21 @@ public:
         auto compute_weight_coord = [&](uint32_t dim) -> Array3 {
             const Value integ = (Value) pos_i[dim];
             const Value alpha = pos_a[dim];
-            Value alpha2 = sqr(alpha), alpha3 = alpha2 * alpha;
+            Value alpha2 = sqr(alpha),
+                  alpha3 = alpha2 * alpha;
             Value multiplier = 1.f / 6.f;
             // four basis functions, transformed to take as input the fractional
             // part
             Value w0 =
                       (-alpha3 + 3.f * alpha2 - 3.f * alpha + 1.f) * multiplier,
                   w1 = (3.f * alpha3 - 6.f * alpha2 + 4.f) * multiplier,
-                  w3 = (alpha3) *multiplier;
-            Value w01 = w0 + w1, w23 = 1.f - w01;
-            return Array3(w01, (integ - 0.5f + w1 / w01) * inv_shape[dim],
-                          (integ + 1.5f + w3 / w23) *
-                              inv_shape[dim]); // (integ + 0.5) +- 1 + weight
+                  w3 = alpha3 * multiplier;
+            Value w01 = w0 + w1,
+                  w23 = 1.f - w01;
+            return Array3(
+               w01,
+               (integ - 0.5f + w1 / w01) * inv_shape[dim],
+               (integ + 1.5f + w3 / w23) * inv_shape[dim]); // (integ + 0.5) +- 1 + weight
         };
 
         auto eval_helper = [&force_enoki, this](const PosF &pos,
@@ -560,15 +558,18 @@ public:
                    f1 = eval_helper(PosF(cx[2]), active);
             result = lerp(f1, f0, cx[0]);
         } else if constexpr (Dimension == 2) {
-            Array3 cx = compute_weight_coord(0), cy = compute_weight_coord(1);
+            Array3 cx = compute_weight_coord(0),
+                   cy = compute_weight_coord(1);
             Array4 f00 = eval_helper(PosF(cx[1], cy[1]), active),
                    f01 = eval_helper(PosF(cx[1], cy[2]), active),
                    f10 = eval_helper(PosF(cx[2], cy[1]), active),
                    f11 = eval_helper(PosF(cx[2], cy[2]), active);
-            Array4 f0 = lerp(f01, f00, cy[0]), f1 = lerp(f11, f10, cy[0]);
+            Array4 f0 = lerp(f01, f00, cy[0]),
+                   f1 = lerp(f11, f10, cy[0]);
             result = lerp(f1, f0, cx[0]);
         } else if constexpr (Dimension == 3) {
-            Array3 cx = compute_weight_coord(0), cy = compute_weight_coord(1),
+            Array3 cx = compute_weight_coord(0),
+                   cy = compute_weight_coord(1),
                    cz = compute_weight_coord(2);
             Array4 f000 = eval_helper(PosF(cx[1], cy[1], cz[1]), active),
                    f001 = eval_helper(PosF(cx[1], cy[1], cz[2]), active),
@@ -578,9 +579,12 @@ public:
                    f101 = eval_helper(PosF(cx[2], cy[1], cz[2]), active),
                    f110 = eval_helper(PosF(cx[2], cy[2], cz[1]), active),
                    f111 = eval_helper(PosF(cx[2], cy[2], cz[2]), active);
-            Array4 f00 = lerp(f001, f000, cz[0]), f01 = lerp(f011, f010, cz[0]),
-                   f10 = lerp(f101, f100, cz[0]), f11 = lerp(f111, f110, cz[0]);
-            Array4 f0 = lerp(f01, f00, cy[0]), f1 = lerp(f11, f10, cy[0]);
+            Array4 f00 = lerp(f001, f000, cz[0]),
+                   f01 = lerp(f011, f010, cz[0]),
+                   f10 = lerp(f101, f100, cz[0]),
+                   f11 = lerp(f111, f110, cz[0]);
+            Array4 f0 = lerp(f01, f00, cy[0]),
+                   f1 = lerp(f11, f10, cy[0]);
             result = lerp(f1, f0, cx[0]);
         }
 
@@ -612,11 +616,7 @@ public:
         PosF pos_f = fmadd(pos, m_shape_opaque, -.5f);
         PosI pos_i = floor2int<PosI>(pos_f);
 
-        Array4 offset;
-        offset[0] = -1;
-        offset[1] = 0;
-        offset[2] = 1;
-        offset[3] = 2;
+        Array4 offset(-1, 0, 1, 2);
 
         InterpPosI pos_i_w(0);
         if constexpr (Dimension == 1) {
@@ -655,16 +655,17 @@ public:
             Value multiplier = rcp(6.f);
             if (!is_grad) {
                 Value alpha3 = alpha2 * alpha;
-                return multiplier *
-                       Array4(-alpha3 + 3.f * alpha2 - 3.f * alpha + 1.f,
-                              3.f * alpha3 - 6.f * alpha2 + 4.f,
-                              -3.f * alpha3 + 3.f * alpha2 + 3.f * alpha + 1.f,
-                              alpha3);
+                return multiplier * Array4(
+                    -alpha3 + 3.f * alpha2 - 3.f * alpha + 1.f,
+                    3.f * alpha3 - 6.f * alpha2 + 4.f,
+                    -3.f * alpha3 + 3.f * alpha2 + 3.f * alpha + 1.f,
+                    alpha3);
             } else {
-                return multiplier * Array4(-3.f * alpha2 + 6.f * alpha - 3.f,
-                                           9.f * alpha2 - 12.f * alpha,
-                                           -9.f * alpha2 + 6.f * alpha + 3.f,
-                                           3.f * alpha2);
+                return multiplier * Array4(
+                    -3.f * alpha2 + 6.f * alpha - 3.f,
+                    9.f * alpha2 - 12.f * alpha,
+                    -9.f * alpha2 + 6.f * alpha + 3.f,
+                    3.f * alpha2);
             }
         };
 
@@ -680,18 +681,18 @@ public:
         const uint32_t channels = (uint32_t) m_value.shape(Dimension);
         index *= channels;
 
-        #define EK_TEX_CUBIC_GATHER(index)                                             \
-            {                                                                          \
-                UInt32 index_ = index;                                                 \
-                for (uint32_t ch = 0; ch < channels; ++ch)                             \
-                    values[ch] = gather<Value>(m_value.array(), index_ + ch, active);  \
+        #define EK_TEX_CUBIC_GATHER(index)                                            \
+            {                                                                         \
+                UInt32 index_ = index;                                                \
+                for (uint32_t ch = 0; ch < channels; ++ch)                            \
+                    values[ch] = gather<Value>(m_value.array(), index_ + ch, active); \
             }
-        #define EK_TEX_CUBIC_ACCUM(dim, weight)                                        \
-            {                                                                          \
-                uint32_t dim_ = dim;                                                   \
-                Value weight_ = weight;                                                \
-                for (uint32_t ch = 0; ch < channels; ++ch)                             \
-                    result[dim_][ch] = fmadd(values[ch], weight_, result[dim_][ch]);   \
+        #define EK_TEX_CUBIC_ACCUM(dim, weight)                                      \
+            {                                                                        \
+                uint32_t dim_ = dim;                                                 \
+                Value weight_ = weight;                                              \
+                for (uint32_t ch = 0; ch < channels; ++ch)                           \
+                    result[dim_][ch] = fmadd(values[ch], weight_, result[dim_][ch]); \
             }
 
         std::array<Array4, Dimension> result;
@@ -706,8 +707,10 @@ public:
                 EK_TEX_CUBIC_ACCUM(0, gx[ix]);
             }
         } else if constexpr (Dimension == 2) {
-            Array4 wx = compute_weight(0, false), wy = compute_weight(1, false),
-                   gx = compute_weight(0, true), gy = compute_weight(1, true);
+            Array4 wx = compute_weight(0, false),
+                   wy = compute_weight(1, false),
+                   gx = compute_weight(0, true),
+                   gy = compute_weight(1, true);
             for (uint32_t ix = 0; ix < 4; ++ix)
                 for (uint32_t iy = 0; iy < 4; ++iy) {
                     EK_TEX_CUBIC_GATHER(index[ix * 4 + iy]);
@@ -715,9 +718,12 @@ public:
                     EK_TEX_CUBIC_ACCUM(1, wx[ix] * gy[iy]);
                 }
         } else if constexpr (Dimension == 3) {
-            Array4 wx = compute_weight(0, false), wy = compute_weight(1, false),
-                   wz = compute_weight(2, false), gx = compute_weight(0, true),
-                   gy = compute_weight(1, true), gz = compute_weight(2, true);
+            Array4 wx = compute_weight(0, false),
+                   wy = compute_weight(1, false),
+                   wz = compute_weight(2, false),
+                   gx = compute_weight(0, true),
+                   gy = compute_weight(1, true),
+                   gz = compute_weight(2, true);
             for (uint32_t ix = 0; ix < 4; ++ix)
                 for (uint32_t iy = 0; iy < 4; ++iy)
                     for (uint32_t iz = 0; iz < 4; ++iz) {

--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -220,8 +220,10 @@ public:
             jit_cuda_tex_lookup(Dimension, m_handle_opaque.index(), pos_idx,
                                 active.index(), out);
 
-            return { Value::steal(out[0]), Value::steal(out[1]),
-                     Value::steal(out[2]), Value::steal(out[3]) };
+            return {
+                Value::steal(out[0]), Value::steal(out[1]),
+                Value::steal(out[2]), Value::steal(out[3])
+            };
         } else {
             (void) pos; (void) active;
             return 0;
@@ -405,7 +407,8 @@ public:
                 for (uint32_t iy = 0; iy < 4; iy++)
                     EK_TEX_CUBIC_ACCUM(idx[ix * 4 + iy], wx[ix] * wy[iy]);
         } else if constexpr (Dimension == 3) {
-            Array4 wx = compute_weight(0), wy = compute_weight(1),
+            Array4 wx = compute_weight(0),
+                   wy = compute_weight(1),
                    wz = compute_weight(2);
             for (uint32_t ix = 0; ix < 4; ix++)
                 for (uint32_t iy = 0; iy < 4; iy++)

--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -31,7 +31,7 @@ public:
     static constexpr bool IsDiff = is_diff_array_v<Value>;
     static constexpr bool IsDynamic = is_dynamic_v<Value>;
 
-    using Int32  = int32_array_t<Value>;
+    using Int32 = int32_array_t<Value>;
     using UInt32 = uint32_array_t<Value>;
     using UInt64 = uint64_array_t<Value>;
     using Mask = mask_t<Value>;
@@ -84,16 +84,16 @@ public:
     }
 
     Texture(Texture &&other) {
-        m_handle         = other.handle;
-        other.handle     = nullptr;
-        m_size           = other.m_size;
-        m_handle_opaque  = std::move(other.m_handle_opaque);
-        m_shape_opaque   = std::move(other.m_shape_opaque);
-        m_value          = std::move(other.m_value);
-        m_migrate        = other.m_migrate;
+        m_handle = other.handle;
+        other.handle = nullptr;
+        m_size = other.m_size;
+        m_handle_opaque = std::move(other.m_handle_opaque);
+        m_shape_opaque = std::move(other.m_shape_opaque);
+        m_value = std::move(other.m_value);
+        m_migrate = other.m_migrate;
         m_inv_resolution = std::move(other.m_inv_resolution);
-        m_filter_mode    = other.m_filter_mode;
-        m_wrap_mode      = other.m_wrap_mode;
+        m_filter_mode = other.m_filter_mode;
+        m_wrap_mode = other.m_wrap_mode;
     }
 
     Texture &operator=(Texture &&other) {
@@ -101,16 +101,16 @@ public:
             jit_cuda_tex_destroy(m_handle);
             m_handle = nullptr;
         }
-        m_handle         = other.m_handle;
-        other.m_handle   = nullptr;
-        m_size           = other.m_size;
-        m_handle_opaque  = std::move(other.m_handle_opaque);
-        m_shape_opaque   = std::move(other.m_shape_opaque);
-        m_value          = std::move(other.m_value);
-        m_migrate        = other.m_migrate;
+        m_handle = other.m_handle;
+        other.m_handle = nullptr;
+        m_size = other.m_size;
+        m_handle_opaque = std::move(other.m_handle_opaque);
+        m_shape_opaque = std::move(other.m_shape_opaque);
+        m_value = std::move(other.m_value);
+        m_migrate = other.m_migrate;
         m_inv_resolution = std::move(other.m_inv_resolution);
-        m_filter_mode    = other.m_filter_mode;
-        m_wrap_mode      = other.m_wrap_mode;
+        m_filter_mode = other.m_filter_mode;
+        m_wrap_mode = other.m_wrap_mode;
         return *this;
     }
 
@@ -246,8 +246,8 @@ public:
         const uint32_t channels = (uint32_t) m_value.shape(Dimension);
 
         if (ENOKI_UNLIKELY(m_filter_mode == FilterMode::Nearest)) {
-            const PosF pos_f   = pos * m_shape_opaque;
-            const PosI pos_i   = floor2int<PosI>(pos_f);
+            const PosF pos_f = pos * m_shape_opaque;
+            const PosI pos_i = floor2int<PosI>(pos_f);
             const PosI pos_i_w = wrap(pos_i);
 
             UInt32 index;
@@ -268,7 +268,7 @@ public:
 
             return result;
         } else {
-            using InterpIdx  = Array<Int32, 1 << Dimension>;
+            using InterpIdx = Array<Int32, 1 << Dimension>;
             using InterpPosI = Array<InterpIdx, Dimension>;
 
             const PosF pos_f = fmadd(pos, m_shape_opaque, -.5f);
@@ -330,6 +330,8 @@ public:
                 EK_TEX_ACCUM(index[7], w1.x() * w1.y() * w1.z());
             }
 
+            #undef EK_TEX_ACCUM
+
             return result;
         }
     }
@@ -371,10 +373,10 @@ public:
      */
     Array<Value, 4> eval_cubic_helper(const Array<Value, Dimension> &pos,
                                       Mask active = true) const {
-        using PosF       = Array<Value, Dimension>;
-        using PosI       = int32_array_t<PosF>;
-        using Array4     = Array<Value, 4>;
-        using InterpIdx  = Array<Int32, 1 << (1 << Dimension)>;
+        using PosF = Array<Value, Dimension>;
+        using PosI = int32_array_t<PosF>;
+        using Array4 = Array<Value, 4>;
+        using InterpIdx = Array<Int32, 1 << (1 << Dimension)>;
         using InterpPosI = Array<InterpIdx, Dimension>;
 
         PosF pos_(pos);
@@ -601,10 +603,10 @@ public:
     std::array<Array<Value, 4>, Dimension>
     eval_cubic_grad(const Array<Value, Dimension> &pos,
                     Mask active = true) const {
-        using PosF       = Array<Value, Dimension>;
-        using PosI       = int32_array_t<PosF>;
-        using Array4     = Array<Value, 4>;
-        using InterpIdx  = Array<Int32, 1 << (1 << Dimension)>;
+        using PosF = Array<Value, Dimension>;
+        using PosI = int32_array_t<PosF>;
+        using Array4 = Array<Value, 4>;
+        using InterpIdx = Array<Int32, 1 << (1 << Dimension)>;
         using InterpPosI = Array<InterpIdx, Dimension>;
 
         PosF pos_f = fmadd(pos, m_shape_opaque, -.5f);
@@ -742,8 +744,8 @@ protected:
         size_t tensor_shape[Dimension + 1]{};
 
         for (size_t i = 0; i < Dimension; ++i) {
-            tensor_shape[i]     = shape[i];
-            m_shape_opaque[i]   = opaque<UInt32>((uint32_t) shape[i]);
+            tensor_shape[i] = shape[i];
+            m_shape_opaque[i] = opaque<UInt32>((uint32_t) shape[i]);
             m_inv_resolution[i] = divisor<int32_t>((int32_t) shape[i]);
             m_size *= shape[i];
         }
@@ -765,7 +767,7 @@ protected:
 
 private:
     void *m_handle = nullptr;
-    size_t m_size  = 0;
+    size_t m_size = 0;
     UInt64 m_handle_opaque;
     Array<UInt32, Dimension> m_shape_opaque;
     mutable TensorXf m_value;

--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -460,15 +460,15 @@ public:
         index *= channels;
         step *= channels;
 
-#define EK_TEX_CUBIC_ACCUM(index, weight)                                      \
-    {                                                                          \
-        UInt32 index_ = index;                                                 \
-        Value weight_ = weight;                                                \
-        for (uint32_t ch = 0; ch < channels; ++ch)                             \
-            result[ch] =                                                       \
-                fmadd(gather<Value>(m_value.array(), index_ + ch, active),     \
-                      weight_, result[ch]);                                    \
-    }
+        #define EK_TEX_CUBIC_ACCUM(index, weight)                                      \
+            {                                                                          \
+                UInt32 index_ = index;                                                 \
+                Value weight_ = weight;                                                \
+                for (uint32_t ch = 0; ch < channels; ++ch)                             \
+                    result[ch] =                                                       \
+                        fmadd(gather<Value>(m_value.array(), index_ + ch, active),     \
+                              weight_, result[ch]);                                    \
+            }
 
         Array<Value, 4> result(0);
 
@@ -493,7 +493,7 @@ public:
                                            wx[ix] * wy[iy] * wz[iz]);
         }
 
-#undef EK_TEX_CUBIC_ACCUM
+        #undef EK_TEX_CUBIC_ACCUM
 
         return result;
     }
@@ -675,19 +675,19 @@ public:
         index *= channels;
         step *= channels;
 
-#define EK_TEX_CUBIC_GATHER(index)                                             \
-    {                                                                          \
-        UInt32 index_ = index;                                                 \
-        for (uint32_t ch = 0; ch < channels; ++ch)                             \
-            values[ch] = gather<Value>(m_value.array(), index_ + ch, active);  \
-    }
-#define EK_TEX_CUBIC_ACCUM(dim, weight)                                        \
-    {                                                                          \
-        uint32_t dim_ = dim;                                                   \
-        Value weight_ = weight;                                                \
-        for (uint32_t ch = 0; ch < channels; ++ch)                             \
-            result[dim_][ch] = fmadd(values[ch], weight_, result[dim_][ch]);   \
-    }
+        #define EK_TEX_CUBIC_GATHER(index)                                             \
+            {                                                                          \
+                UInt32 index_ = index;                                                 \
+                for (uint32_t ch = 0; ch < channels; ++ch)                             \
+                    values[ch] = gather<Value>(m_value.array(), index_ + ch, active);  \
+            }
+        #define EK_TEX_CUBIC_ACCUM(dim, weight)                                        \
+            {                                                                          \
+                uint32_t dim_ = dim;                                                   \
+                Value weight_ = weight;                                                \
+                for (uint32_t ch = 0; ch < channels; ++ch)                             \
+                    result[dim_][ch] = fmadd(values[ch], weight_, result[dim_][ch]);   \
+            }
 
         std::array<Array4, Dimension> result;
         for (uint32_t dim = 0; dim < Dimension; ++dim)
@@ -724,8 +724,8 @@ public:
                     }
         }
 
-#undef EK_TEX_CUBIC_GATHER
-#undef EK_TEX_CUBIC_ACCUM
+        #undef EK_TEX_CUBIC_GATHER
+        #undef EK_TEX_CUBIC_ACCUM
 
         return result;
     }

--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -220,12 +220,11 @@ public:
             jit_cuda_tex_lookup(Dimension, m_handle_opaque.index(), pos_idx,
                                 active.index(), out);
 
-            return {
-                Value::steal(out[0]), Value::steal(out[1]),
-                Value::steal(out[2]), Value::steal(out[3])
-            };
+            return { Value::steal(out[0]), Value::steal(out[1]),
+                     Value::steal(out[2]), Value::steal(out[3]) };
         } else {
-            (void) pos; (void) active;
+            (void) pos;
+            (void) active;
             return 0;
         }
     }
@@ -408,8 +407,7 @@ public:
                 for (uint32_t iy = 0; iy < 4; iy++)
                     EK_TEX_CUBIC_ACCUM(idx[ix * 4 + iy], wx[ix] * wy[iy]);
         } else if constexpr (Dimension == 3) {
-            Array4 wx = compute_weight(0),
-                   wy = compute_weight(1),
+            Array4 wx = compute_weight(0), wy = compute_weight(1),
                    wz = compute_weight(2);
             for (uint32_t ix = 0; ix < 4; ix++)
                 for (uint32_t iy = 0; iy < 4; iy++)
@@ -418,7 +416,7 @@ public:
                                            wx[ix] * wy[iy] * wz[iz]);
         }
 
-        #undef EK_TEX_CUBIC_ACCUM
+#undef EK_TEX_CUBIC_ACCUM
 
         return result;
     }
@@ -468,8 +466,7 @@ public:
         auto compute_weight_coord = [&](uint32_t dim) -> Array3 {
             const Value integ = (Value) pos_i[dim];
             const Value alpha = pos_a[dim];
-            Value alpha2 = sqr(alpha),
-                  alpha3 = alpha2 * alpha;
+            Value alpha2 = sqr(alpha), alpha3 = alpha2 * alpha;
             Value multiplier = 1.f / 6.f;
             // four basis functions, transformed to take as input the fractional part
             Value w0 =
@@ -502,18 +499,15 @@ public:
                    f1 = eval_helper(PosF(cx[2]), active);
             result = lerp(f1, f0, cx[0]);
         } else if constexpr (Dimension == 2) {
-            Array3 cx = compute_weight_coord(0),
-                   cy = compute_weight_coord(1);
+            Array3 cx = compute_weight_coord(0), cy = compute_weight_coord(1);
             Array4 f00 = eval_helper(PosF(cx[1], cy[1]), active),
                    f01 = eval_helper(PosF(cx[1], cy[2]), active),
                    f10 = eval_helper(PosF(cx[2], cy[1]), active),
                    f11 = eval_helper(PosF(cx[2], cy[2]), active);
-            Array4 f0 = lerp(f01, f00, cy[0]),
-                   f1 = lerp(f11, f10, cy[0]);
+            Array4 f0 = lerp(f01, f00, cy[0]), f1 = lerp(f11, f10, cy[0]);
             result = lerp(f1, f0, cx[0]);
         } else if constexpr (Dimension == 3) {
-            Array3 cx = compute_weight_coord(0),
-                   cy = compute_weight_coord(1),
+            Array3 cx = compute_weight_coord(0), cy = compute_weight_coord(1),
                    cz = compute_weight_coord(2);
             Array4 f000 = eval_helper(PosF(cx[1], cy[1], cz[1]), active),
                    f001 = eval_helper(PosF(cx[1], cy[1], cz[2]), active),
@@ -523,12 +517,9 @@ public:
                    f101 = eval_helper(PosF(cx[2], cy[1], cz[2]), active),
                    f110 = eval_helper(PosF(cx[2], cy[2], cz[1]), active),
                    f111 = eval_helper(PosF(cx[2], cy[2], cz[2]), active);
-            Array4 f00 = lerp(f001, f000, cz[0]),
-                   f01 = lerp(f011, f010, cz[0]),
-                   f10 = lerp(f101, f100, cz[0]),
-                   f11 = lerp(f111, f110, cz[0]);
-            Array4 f0 = lerp(f01, f00, cy[0]),
-                   f1 = lerp(f11, f10, cy[0]);
+            Array4 f00 = lerp(f001, f000, cz[0]), f01 = lerp(f011, f010, cz[0]),
+                   f10 = lerp(f101, f100, cz[0]), f11 = lerp(f111, f110, cz[0]);
+            Array4 f0 = lerp(f01, f00, cy[0]), f1 = lerp(f11, f10, cy[0]);
             result = lerp(f1, f0, cx[0]);
         }
 
@@ -545,7 +536,7 @@ public:
         return result;
     }
 
-    /// Evaluate the positional gradient of a cubic B-Spline from the
+    /// Evaluate the positional gradient of clamped cubic B-Spline from the
     /// explicit differentiated basis functions
     std::array<Array<Value, 4>, Dimension>
     eval_cubic_grad(const Array<Value, Dimension> &pos,
@@ -591,19 +582,19 @@ public:
 
         const uint32_t channels = (uint32_t) m_value.shape(Dimension);
 
-        #define EK_TEX_CUBIC_GATHER(index)                                            \
-            {                                                                         \
-                UInt32 index_ = index;                                                \
-                for (uint32_t ch = 0; ch < channels; ++ch)                            \
-                    values[ch] = gather<Value>(m_value.array(), index_ + ch, active); \
-            }
-        #define EK_TEX_CUBIC_ACCUM(dim, weight)                                      \
-            {                                                                        \
-                uint32_t dim_ = dim;                                                 \
-                Value weight_ = weight;                                              \
-                for (uint32_t ch = 0; ch < channels; ++ch)                           \
-                    result[dim_][ch] = fmadd(values[ch], weight_, result[dim_][ch]); \
-            }
+#define EK_TEX_CUBIC_GATHER(index)                                             \
+    {                                                                          \
+        UInt32 index_ = index;                                                 \
+        for (uint32_t ch = 0; ch < channels; ++ch)                             \
+            values[ch] = gather<Value>(m_value.array(), index_ + ch, active);  \
+    }
+#define EK_TEX_CUBIC_ACCUM(dim, weight)                                        \
+    {                                                                          \
+        uint32_t dim_ = dim;                                                   \
+        Value weight_ = weight;                                                \
+        for (uint32_t ch = 0; ch < channels; ++ch)                             \
+            result[dim_][ch] = fmadd(values[ch], weight_, result[dim_][ch]);   \
+    }
 
         std::array<Array4, Dimension> result;
         for (uint32_t dim = 0; dim < Dimension; ++dim)
@@ -617,10 +608,8 @@ public:
                 EK_TEX_CUBIC_ACCUM(0, gx[ix]);
             }
         } else if constexpr (Dimension == 2) {
-            Array4 wx = compute_weight(0, false),
-                   wy = compute_weight(1, false),
-                   gx = compute_weight(0, true),
-                   gy = compute_weight(1, true);
+            Array4 wx = compute_weight(0, false), wy = compute_weight(1, false),
+                   gx = compute_weight(0, true), gy = compute_weight(1, true);
             for (uint32_t ix = 0; ix < 4; ++ix)
                 for (uint32_t iy = 0; iy < 4; ++iy) {
                     EK_TEX_CUBIC_GATHER(idx[ix * 4 + iy]);
@@ -628,12 +617,9 @@ public:
                     EK_TEX_CUBIC_ACCUM(1, wx[ix] * gy[iy]);
                 }
         } else if constexpr (Dimension == 3) {
-            Array4 wx = compute_weight(0, false),
-                   wy = compute_weight(1, false),
-                   wz = compute_weight(2, false),
-                   gx = compute_weight(0, true),
-                   gy = compute_weight(1, true),
-                   gz = compute_weight(2, true);
+            Array4 wx = compute_weight(0, false), wy = compute_weight(1, false),
+                   wz = compute_weight(2, false), gx = compute_weight(0, true),
+                   gy = compute_weight(1, true), gz = compute_weight(2, true);
             for (uint32_t ix = 0; ix < 4; ++ix)
                 for (uint32_t iy = 0; iy < 4; ++iy)
                     for (uint32_t iz = 0; iz < 4; ++iz) {
@@ -644,8 +630,8 @@ public:
                     }
         }
 
-        #undef EK_TEX_CUBIC_GATHER
-        #undef EK_TEX_CUBIC_ACCUM
+#undef EK_TEX_CUBIC_GATHER
+#undef EK_TEX_CUBIC_ACCUM
 
         return result;
     }

--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -415,7 +415,7 @@ public:
                                            wx[ix] * wy[iy] * wz[iz]);
         }
 
-#undef EK_TEX_CUBIC_ACCUM
+        #undef EK_TEX_CUBIC_ACCUM
 
         return result;
     }
@@ -581,19 +581,19 @@ public:
 
         const uint32_t channels = (uint32_t) m_value.shape(Dimension);
 
-#define EK_TEX_CUBIC_GATHER(index)                                             \
-    {                                                                          \
-        UInt32 index_ = index;                                                 \
-        for (uint32_t ch = 0; ch < channels; ++ch)                             \
-            values[ch] = gather<Value>(m_value.array(), index_ + ch, active);  \
-    }
-#define EK_TEX_CUBIC_ACCUM(dim, weight)                                        \
-    {                                                                          \
-        uint32_t dim_ = dim;                                                   \
-        Value weight_ = weight;                                                \
-        for (uint32_t ch = 0; ch < channels; ++ch)                             \
-            result[dim_][ch] = fmadd(values[ch], weight_, result[dim_][ch]);   \
-    }
+        #define EK_TEX_CUBIC_GATHER(index)                                             \
+            {                                                                          \
+                UInt32 index_ = index;                                                 \
+                for (uint32_t ch = 0; ch < channels; ++ch)                             \
+                    values[ch] = gather<Value>(m_value.array(), index_ + ch, active);  \
+            }
+        #define EK_TEX_CUBIC_ACCUM(dim, weight)                                        \
+            {                                                                          \
+                uint32_t dim_ = dim;                                                   \
+                Value weight_ = weight;                                                \
+                for (uint32_t ch = 0; ch < channels; ++ch)                             \
+                    result[dim_][ch] = fmadd(values[ch], weight_, result[dim_][ch]);   \
+            }
 
         std::array<Array4, Dimension> result;
         for (uint32_t dim = 0; dim < Dimension; ++dim)
@@ -629,8 +629,8 @@ public:
                     }
         }
 
-#undef EK_TEX_CUBIC_GATHER
-#undef EK_TEX_CUBIC_ACCUM
+        #undef EK_TEX_CUBIC_GATHER
+        #undef EK_TEX_CUBIC_ACCUM
 
         return result;
     }

--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -682,7 +682,7 @@ protected:
 
 private:
     template <typename T>
-        constexpr static T ipow(T num, unsigned int pow) {
+    constexpr static T ipow(T num, unsigned int pow) {
         return pow == 0 ? 1 : num * ipow(num, pow - 1);
     }
 
@@ -694,9 +694,9 @@ private:
         using InterpPosI = Array<InterpOffset, Dimension>;
 
         static_assert(
-                array_size_v<T> == Dimension &&
-                std::is_integral_v<Scalar> &&
-                std::is_signed_v<Scalar>
+            array_size_v<T> == Dimension &&
+            std::is_integral_v<Scalar> &&
+            std::is_signed_v<Scalar>
         );
 
         InterpPosI pos_i(0);
@@ -733,9 +733,9 @@ private:
     template <typename T> T wrap(const T &pos) const {
         using Scalar = scalar_t<T>;
         static_assert(
-                array_size_v<T> == Dimension &&
-                std::is_integral_v<Scalar> &&
-                std::is_signed_v<Scalar>
+            array_size_v<T> == Dimension &&
+            std::is_integral_v<Scalar> &&
+            std::is_signed_v<Scalar>
         );
 
         const Array<Int32, Dimension> shape = m_shape_opaque;
@@ -773,15 +773,16 @@ private:
         );
 
         Index index;
-        if constexpr (Dimension == 1)
+        if constexpr (Dimension == 1) {
             index = Index(pos.x());
-        else if constexpr (Dimension == 2)
+        } else if constexpr (Dimension == 2) {
             index = Index(
                 fmadd(Index(pos.y()), m_shape_opaque.x(), Index(pos.x())));
-        else if constexpr (Dimension == 3)
+        } else if constexpr (Dimension == 3) {
             index = Index(fmadd(
                 fmadd(Index(pos.z()), m_shape_opaque.y(), Index(pos.y())),
                 m_shape_opaque.x(), Index(pos.x())));
+        }
 
         const uint32_t channels = (uint32_t) m_value.shape(Dimension);
 

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -118,6 +118,11 @@ PYBIND11_MODULE(enoki_ext, m_) {
         .value("Nearest", ek::FilterMode::Nearest)
         .value("Linear", ek::FilterMode::Linear);
 
+    py::enum_<ek::WrapMode>(m, "WrapMode")
+        .value("Repeat", ek::WrapMode::Repeat)
+        .value("Clamp", ek::WrapMode::Clamp)
+        .value("Mirror", ek::WrapMode::Mirror);
+
     py::class_<ek::detail::reinterpret_flag>(array_detail, "reinterpret_flag")
         .def(py::init<>());
 

--- a/src/python/texture.h
+++ b/src/python/texture.h
@@ -16,12 +16,12 @@ void bind_texture(py::module &m, const char *name) {
              }),
              "shape"_a, "channels"_a, "migrate"_a = true,
              "filter_mode"_a = ek::FilterMode::Linear,
-             "wrap_mode"_a   = ek::WrapMode::Repeat)
+             "wrap_mode"_a = ek::WrapMode::Repeat)
         .def(py::init<const typename Tex::TensorXf &, bool, ek::FilterMode,
                       ek::WrapMode>(),
              "tensor"_a, "migrate"_a = true,
              "filter_mode"_a = ek::FilterMode::Linear,
-             "wrap_mode"_a   = ek::WrapMode::Repeat)
+             "wrap_mode"_a = ek::WrapMode::Repeat)
         .def("set_value", &Tex::set_value, "value"_a)
         .def("set_tensor", &Tex::set_tensor, "tensor"_a)
         .def("value", &Tex::value, py::return_value_policy::reference_internal)

--- a/src/python/texture.h
+++ b/src/python/texture.h
@@ -25,8 +25,7 @@ void bind_texture(py::module &m, const char *name) {
         .def("set_value", &Tex::set_value, "value"_a)
         .def("set_tensor", &Tex::set_tensor, "tensor"_a)
         .def("value", &Tex::value, py::return_value_policy::reference_internal)
-        .def("tensor", &Tex::tensor,
-             py::return_value_policy::reference_internal)
+        .def("tensor", &Tex::tensor, py::return_value_policy::reference_internal)
         .def("filter_mode", &Tex::filter_mode)
         .def("wrap_mode", &Tex::wrap_mode)
         .def("eval_cuda", &Tex::eval_cuda, "pos"_a, "active"_a = true)
@@ -38,7 +37,8 @@ void bind_texture(py::module &m, const char *name) {
     tex.attr("IsTexture") = true;
 }
 
-template <typename Type> void bind_texture_all(py::module &m) {
+template <typename Type>
+void bind_texture_all(py::module &m) {
     bind_texture<Type, 1>(m, "Texture1f");
     bind_texture<Type, 2>(m, "Texture2f");
     bind_texture<Type, 3>(m, "Texture3f");

--- a/src/python/texture.h
+++ b/src/python/texture.h
@@ -16,12 +16,12 @@ void bind_texture(py::module &m, const char *name) {
              }),
              "shape"_a, "channels"_a, "migrate"_a = true,
              "filter_mode"_a = ek::FilterMode::Linear,
-             "wrap_mode"_a = ek::WrapMode::Repeat)
+             "wrap_mode"_a = ek::WrapMode::Clamp)
         .def(py::init<const typename Tex::TensorXf &, bool, ek::FilterMode,
                       ek::WrapMode>(),
              "tensor"_a, "migrate"_a = true,
              "filter_mode"_a = ek::FilterMode::Linear,
-             "wrap_mode"_a = ek::WrapMode::Repeat)
+             "wrap_mode"_a = ek::WrapMode::Clamp)
         .def("set_value", &Tex::set_value, "value"_a)
         .def("set_tensor", &Tex::set_tensor, "tensor"_a)
         .def("value", &Tex::value, py::return_value_policy::reference_internal)

--- a/src/python/texture.h
+++ b/src/python/texture.h
@@ -10,19 +10,25 @@ void bind_texture(py::module &m, const char *name) {
     auto tex = py::class_<Tex>(m, name)
         .def(py::init([](const std::array<size_t, Dimension> &shape,
                          size_t channels, bool migrate,
-                         ek::FilterMode filter_mode) {
-                 return new Tex(shape.data(), channels, migrate, filter_mode);
+                         ek::FilterMode filter_mode, ek::WrapMode wrap_mode) {
+                 return new Tex(shape.data(), channels, migrate, filter_mode,
+                                wrap_mode);
              }),
              "shape"_a, "channels"_a, "migrate"_a = true,
-             "filter_mode"_a = ek::FilterMode::Linear)
-        .def(py::init<const typename Tex::TensorXf &, bool, ek::FilterMode>(),
+             "filter_mode"_a = ek::FilterMode::Linear,
+             "wrap_mode"_a   = ek::WrapMode::Repeat)
+        .def(py::init<const typename Tex::TensorXf &, bool, ek::FilterMode,
+                      ek::WrapMode>(),
              "tensor"_a, "migrate"_a = true,
-             "filter_mode"_a = ek::FilterMode::Linear)
+             "filter_mode"_a = ek::FilterMode::Linear,
+             "wrap_mode"_a   = ek::WrapMode::Repeat)
         .def("set_value", &Tex::set_value, "value"_a)
         .def("set_tensor", &Tex::set_tensor, "tensor"_a)
         .def("value", &Tex::value, py::return_value_policy::reference_internal)
-        .def("tensor", &Tex::tensor, py::return_value_policy::reference_internal)
+        .def("tensor", &Tex::tensor,
+             py::return_value_policy::reference_internal)
         .def("filter_mode", &Tex::filter_mode)
+        .def("wrap_mode", &Tex::wrap_mode)
         .def("eval_cuda", &Tex::eval_cuda, "pos"_a, "active"_a = true)
         .def("eval_enoki", &Tex::eval_enoki, "pos"_a, "active"_a = true)
         .def("eval_cubic", &Tex::eval_cubic, "pos"_a, "active"_a = true, "force_enoki"_a = false)
@@ -32,8 +38,7 @@ void bind_texture(py::module &m, const char *name) {
     tex.attr("IsTexture") = true;
 }
 
-template <typename Type>
-void bind_texture_all(py::module &m) {
+template <typename Type> void bind_texture_all(py::module &m) {
     bind_texture<Type, 1>(m, "Texture1f");
     bind_texture<Type, 2>(m, "Texture2f");
     bind_texture<Type, 3>(m, "Texture3f");

--- a/src/python/texture.h
+++ b/src/python/texture.h
@@ -1,3 +1,6 @@
+#pragma once
+
+#include "common.h"
 #include <enoki/texture.h>
 
 template <typename Type, size_t Dimension>

--- a/tests/texture.cpp
+++ b/tests/texture.cpp
@@ -18,8 +18,6 @@ using ArrayD4f = ek::Array<DFloat, 4>;
 
 void test_interp_1d_wrap(WrapMode wrap_mode) {
     for (int k = 0; k < 2; ++k) {
-        jit_set_flag(JitFlag::ForceOptiX, k == 1);
-
         size_t shape[1] = { 2 };
         ek::Texture<Float, 1> tex(shape, 1, false, FilterMode::Linear,
                                   wrap_mode);
@@ -68,6 +66,14 @@ void test_interp_1d_wrap(WrapMode wrap_mode) {
             }
         }
     }
+}
+
+ENOKI_TEST(test01_interp_1d) {
+    jit_init(JitBackend::CUDA);
+
+    test_interp_1d_wrap(WrapMode::Repeat);
+    test_interp_1d_wrap(WrapMode::Clamp);
+    test_interp_1d_wrap(WrapMode::Mirror);
 
     jit_set_flag(JitFlag::ForceOptiX, false);
 }

--- a/tests/texture.cpp
+++ b/tests/texture.cpp
@@ -18,6 +18,8 @@ using ArrayD4f = ek::Array<DFloat, 4>;
 
 void test_interp_1d_wrap(WrapMode wrap_mode) {
     for (int k = 0; k < 2; ++k) {
+        jit_set_flag(JitFlag::ForceOptiX, k == 1);
+
         size_t shape[1] = { 2 };
         ek::Texture<Float, 1> tex(shape, 1, false, FilterMode::Linear,
                                   wrap_mode);
@@ -66,6 +68,8 @@ void test_interp_1d_wrap(WrapMode wrap_mode) {
             }
         }
     }
+
+    jit_set_flag(JitFlag::ForceOptiX, false);
 }
 
 ENOKI_TEST(test01_interp_1d) {
@@ -74,8 +78,6 @@ ENOKI_TEST(test01_interp_1d) {
     test_interp_1d_wrap(WrapMode::Repeat);
     test_interp_1d_wrap(WrapMode::Clamp);
     test_interp_1d_wrap(WrapMode::Mirror);
-
-    jit_set_flag(JitFlag::ForceOptiX, false);
 }
 
 ENOKI_TEST(test01_interp_1d) {

--- a/tests/texture.cpp
+++ b/tests/texture.cpp
@@ -18,6 +18,8 @@ using ArrayD4f = ek::Array<DFloat, 4>;
 
 void test_interp_1d_wrap(WrapMode wrap_mode) {
     for (int k = 0; k < 2; ++k) {
+        jit_set_flag(JitFlag::ForceOptiX, k == 1);
+
         size_t shape[1] = { 2 };
         ek::Texture<Float, 1> tex(shape, 1, false, FilterMode::Linear,
                                   wrap_mode);
@@ -66,6 +68,8 @@ void test_interp_1d_wrap(WrapMode wrap_mode) {
             }
         }
     }
+
+    jit_set_flag(JitFlag::ForceOptiX, false);
 }
 
 ENOKI_TEST(test01_interp_1d) {
@@ -74,8 +78,6 @@ ENOKI_TEST(test01_interp_1d) {
     test_interp_1d_wrap(WrapMode::Repeat);
     test_interp_1d_wrap(WrapMode::Clamp);
     test_interp_1d_wrap(WrapMode::Mirror);
-
-    jit_set_flag(JitFlag::ForceOptiX, false);
 }
 
 ENOKI_TEST(test02_interp_1d) {

--- a/tests/texture.cpp
+++ b/tests/texture.cpp
@@ -161,13 +161,13 @@ void test_grad(bool migrate) {
     if (migrate)
         assert(ek::allclose(out2.x(), 0));
     else
-        assert(ek::allclose(out2.x(), expected, 5e-3, 5e-3f));
+        assert(ek::allclose(out2.x(), expected, 5e-3f, 5e-3f));
 
     auto out = tex.eval(pos);
     ek::backward(out.x());
 
     assert(ek::allclose(ek::grad(value), DFloat(.25f, .75f, 0)));
-    assert(ek::allclose(out.x(), expected, 5e-3, 5e-3f));
+    assert(ek::allclose(out.x(), expected, 5e-3f, 5e-3f));
     assert(ek::allclose(tex.value(), value));
 }
 

--- a/tests/texture.cpp
+++ b/tests/texture.cpp
@@ -80,14 +80,6 @@ ENOKI_TEST(test01_interp_1d) {
     test_interp_1d_wrap(WrapMode::Mirror);
 }
 
-ENOKI_TEST(test01_interp_1d) {
-    jit_init(JitBackend::CUDA);
-
-    test_interp_1d_wrap(WrapMode::Repeat);
-    test_interp_1d_wrap(WrapMode::Clamp);
-    test_interp_1d_wrap(WrapMode::Mirror);
-}
-
 ENOKI_TEST(test02_interp_1d) {
     for (int ch = 1; ch <= 4; ++ch) {
         if (ch == 3)

--- a/tests/texture.cpp
+++ b/tests/texture.cpp
@@ -87,18 +87,23 @@ ENOKI_TEST(test02_interp_1d) {
         size_t shape[] = { 123 };
         PCG32<Float> rng_1(shape[0] * ch);
         PCG32<Float> rng_2(1024);
+        Array<WrapMode, 3> wrap_modes(WrapMode::Repeat, WrapMode::Clamp,
+                                      WrapMode::Mirror);
 
-        Texture<Float, 1> tex(shape, ch, false);
-        for (int i = 0; i < 4; ++i) {
-            tex.set_value(rng_1.next_float32());
+        for (size_t i = 0; i < wrap_modes.size(); ++i) {
+            Texture<Float, 1> tex(shape, ch, false, FilterMode::Linear,
+                                  wrap_modes[i]);
 
-            Array1f pos(rng_2.next_float32());
-            Array4f result_enoki = tex.eval_enoki(pos);
-            ek::eval(result_enoki);
-            Array4f result_cuda = tex.eval_cuda(pos);
-            ek::eval(result_cuda);
+            for (int i = 0; i < 4; ++i) {
+                tex.set_value(rng_1.next_float32());
+                Array1f pos(rng_2.next_float32());
+                Array4f result_enoki = tex.eval_enoki(pos);
+                ek::eval(result_enoki);
+                Array4f result_cuda = tex.eval_cuda(pos);
+                ek::eval(result_cuda);
 
-            assert(ek::allclose(result_enoki, result_cuda, 5e-3f, 5e-3f));
+                assert(ek::allclose(result_enoki, result_cuda, 5e-3f, 5e-3f));
+            }
         }
     }
 }
@@ -110,17 +115,22 @@ ENOKI_TEST(test03_interp_2d) {
         size_t shape[] = { 123, 456 };
         PCG32<Float> rng_1(shape[0] * shape[1] * ch);
         PCG32<Float> rng_2(1024);
+        Array<WrapMode, 3> wrap_modes(WrapMode::Repeat, WrapMode::Clamp,
+                                      WrapMode::Mirror);
 
-        Texture<Float, 2> tex(shape, ch, false);
-        for (int i = 0; i < 4; ++i) {
-            tex.set_value(rng_1.next_float32());
+        for (size_t i = 0; i < wrap_modes.size(); ++i) {
+            Texture<Float, 2> tex(shape, ch, false, FilterMode::Linear,
+                                  wrap_modes[i]);
 
-            Array2f pos(rng_2.next_float32(), rng_2.next_float32());
-            Array4f result_enoki = tex.eval_enoki(pos);
-            ek::eval(result_enoki);
-            Array4f result_cuda = tex.eval_cuda(pos);
-            ek::eval(result_cuda);
-            assert(ek::allclose(result_enoki, result_cuda, 5e-3f, 5e-3f));
+            for (int i = 0; i < 4; ++i) {
+                tex.set_value(rng_1.next_float32());
+                Array2f pos(rng_2.next_float32(), rng_2.next_float32());
+                Array4f result_enoki = tex.eval_enoki(pos);
+                ek::eval(result_enoki);
+                Array4f result_cuda = tex.eval_cuda(pos);
+                ek::eval(result_cuda);
+                assert(ek::allclose(result_enoki, result_cuda, 5e-3f, 5e-3f));
+            }
         }
     }
 }
@@ -132,18 +142,24 @@ ENOKI_TEST(test04_interp_3d) {
         size_t shape[] = { 123, 456, 12 };
         PCG32<Float> rng_1(shape[0] * shape[1] * shape[2] * ch);
         PCG32<Float> rng_2(1024);
+        Array<WrapMode, 3> wrap_modes(WrapMode::Repeat, WrapMode::Clamp,
+                                      WrapMode::Mirror);
 
-        Texture<Float, 3> tex(shape, ch, false);
-        for (int i = 0; i < 4; ++i) {
-            tex.set_value(rng_1.next_float32());
+        for (size_t i = 0; i < wrap_modes.size(); ++i) {
+            Texture<Float, 3> tex(shape, ch, false, FilterMode::Linear,
+                                  wrap_modes[i]);
 
-            Array3f pos(rng_2.next_float32(), rng_2.next_float32(),
-                        rng_2.next_float32());
-            Array4f result_enoki = tex.eval_enoki(pos);
-            ek::eval(result_enoki);
-            Array4f result_cuda = tex.eval_cuda(pos);
-            ek::eval(result_cuda);
-            assert(ek::allclose(result_enoki, result_cuda, 5e-3f, 5e-3f));
+            for (int i = 0; i < 4; ++i) {
+                tex.set_value(rng_1.next_float32());
+
+                Array3f pos(rng_2.next_float32(), rng_2.next_float32(),
+                            rng_2.next_float32());
+                Array4f result_enoki = tex.eval_enoki(pos);
+                ek::eval(result_enoki);
+                Array4f result_cuda = tex.eval_cuda(pos);
+                ek::eval(result_cuda);
+                assert(ek::allclose(result_enoki, result_cuda, 5e-3f, 5e-3f));
+            }
         }
     }
 }

--- a/tests/texture.cpp
+++ b/tests/texture.cpp
@@ -189,7 +189,8 @@ ENOKI_TEST(test06_nearest) {
 
 ENOKI_TEST(test07_cubic_analytic) {
     size_t shape[1] = { 4 };
-    ek::Texture<DFloat, 1> tex(shape, 1, false);
+    ek::Texture<DFloat, 1> tex(shape, 1, false, FilterMode::Linear,
+                               WrapMode::Clamp);
     tex.set_value(DFloat(0.f, 1.f, 0.f, 0.f));
 
     ArrayD1f pos(0.5f);
@@ -212,7 +213,8 @@ ENOKI_TEST(test07_cubic_analytic) {
 
 ENOKI_TEST(test08_cubic_interp_1d) {
     size_t shape[1] = { 5 };
-    ek::Texture<Float, 1> tex(shape, 1, false);
+    ek::Texture<Float, 1> tex(shape, 1, false, FilterMode::Linear,
+                              WrapMode::Clamp);
     tex.set_value(Float(2.f, 1.f, 3.f, 4.f, 7.f));
 
     size_t N = 20;
@@ -228,7 +230,8 @@ ENOKI_TEST(test08_cubic_interp_1d) {
 
 ENOKI_TEST(test09_cubic_interp_2d) {
     size_t shape[2] = { 5, 4 };
-    ek::Texture<Float, 2> tex(shape, 1, false);
+    ek::Texture<Float, 2> tex(shape, 1, false, FilterMode::Linear,
+                              WrapMode::Clamp);
     tex.set_value(ek::linspace<Float>(0.f, 20.f, 20));
 
     size_t N = 30;
@@ -257,7 +260,8 @@ ENOKI_TEST(test10_cubic_interp_3d) {
     ek::scatter(tensor.array(), Float(2.0),  Uint32(546));  // tensor[3, 3, 3, 0] = 2.0
     ek::scatter(tensor.array(), Float(10.0), Uint32(727));  // tensor[4, 4, 3, 1] = 10.0
 
-    ek::Texture<Float, 3> tex(shape, 2, false);
+    ek::Texture<Float, 3> tex(shape, 2, false, FilterMode::Linear,
+                              WrapMode::Clamp);
     tex.set_tensor(tensor);
 
     Array4f ref(0.71312, 1.86141, 0.0, 0.0);
@@ -288,7 +292,8 @@ ENOKI_TEST(test11_cubic_grad_pos) {
     ek::scatter(tensor.array(), Float(3.0f), Uint32(41));  // data[2, 2, 1] = 3.0
     ek::scatter(tensor.array(), Float(4.0f), Uint32(22));  // data[1, 1, 2] = 4.0
 
-    ek::Texture<DFloat, 3> tex(shape, 1, false);
+    ek::Texture<DFloat, 3> tex(shape, 1, false, FilterMode::Linear,
+                               WrapMode::Clamp);
     tex.set_tensor(tensor);
 
     ArrayD3f pos(.5f, .5f, .5f);


### PR DESCRIPTION
This PR adds a `WrapMode` `enum` to extend the possible texture wrapping modes with: clamping, repeating.

The `WrapMode` is used both by the `eval()` (`eval_cuda()` and `eval_enoki()`) method with the existing filtering methods, as well as all the cubic spline interpolation methods (`eval_cubic()`, `eval_cubic_helper`, `eval_cubic_grad`).

Tests cover the new wrapping modes in all aforementioned methods, for 1, 2 and 3 dimensional textures.


Notes:
I do not know the fine details of the current & future cubic spline interpolation methods use cases, but it seems to me like we could expose them through an unified interface by adding a `CubicSpline` variant to `FilterMode`. Alternatively we maybe should/could add a warning when using the cubic spline interpolation methods with the `FilterMode` being set to `Nearest`.