### PR TITLE
Texture: fix move semantics

### DIFF
--- a/include/enoki/texture.h
+++ b/include/enoki/texture.h
@@ -103,14 +103,15 @@ public:
     }
 
     Texture(Texture &&other) {
-        m_handle = other.handle;
-        other.handle = nullptr;
+        m_handle = other.m_handle;
+        other.m_handle = nullptr;
         m_size = other.m_size;
         m_handle_opaque = std::move(other.m_handle_opaque);
         m_shape_opaque = std::move(other.m_shape_opaque);
         m_value = std::move(other.m_value);
         m_migrate = other.m_migrate;
-        m_inv_resolution = std::move(other.m_inv_resolution);
+        for (size_t i = 0; i < Dimension; ++i)
+            m_inv_resolution[i] = std::move(other.m_inv_resolution[i]);
         m_filter_mode = other.m_filter_mode;
         m_wrap_mode = other.m_wrap_mode;
     }
@@ -127,7 +128,8 @@ public:
         m_shape_opaque = std::move(other.m_shape_opaque);
         m_value = std::move(other.m_value);
         m_migrate = other.m_migrate;
-        m_inv_resolution = std::move(other.m_inv_resolution);
+        for (size_t i = 0; i < Dimension; ++i)
+            m_inv_resolution[i] = std::move(other.m_inv_resolution[i]);
         m_filter_mode = other.m_filter_mode;
         m_wrap_mode = other.m_wrap_mode;
         return *this;

--- a/tests/texture.cpp
+++ b/tests/texture.cpp
@@ -399,3 +399,38 @@ ENOKI_TEST(test11_cubic_grad_pos) {
     assert(ek::allclose(grad_64[2][0], ref_grad[2], 1e-5f, 1e-5f));
     assert(ek::allclose(grad_ad, ref_grad, 1e-5f, 1e-5f));
 }
+
+ENOKI_TEST(test12_move_assignment) {
+    size_t shape[1] = { 2 };
+    ek::Texture<Float, 1> move_from(shape, 1, false, FilterMode::Nearest,
+                              WrapMode::Repeat);
+    move_from.set_value(Float(0.f, 1.f));
+    const void *from_handle = move_from.handle();
+
+    ek::Texture<Float, 1> move_to;
+    move_to = std::move(move_from);
+
+    assert(move_to.ndim() == 2);
+    assert(move_to.handle() == from_handle);
+    assert(move_from.handle() == nullptr);
+    assert(move_to.shape()[0] == shape[0]);
+    assert(move_to.wrap_mode() == WrapMode::Repeat);
+    assert(move_to.filter_mode() == FilterMode::Nearest);
+}
+
+ENOKI_TEST(test13_move_constructor) {
+    size_t shape[1] = { 2 };
+    ek::Texture<Float, 1> move_from(shape, 1, false, FilterMode::Nearest,
+                              WrapMode::Repeat);
+    move_from.set_value(Float(0.f, 1.f));
+    const void *from_handle = move_from.handle();
+
+    ek::Texture<Float, 1> move_to(std::move(move_from));
+
+    assert(move_to.ndim() == 2);
+    assert(move_to.handle() == from_handle);
+    assert(move_from.handle() == nullptr);
+    assert(move_to.shape()[0] == shape[0]);
+    assert(move_to.wrap_mode() == WrapMode::Repeat);
+    assert(move_to.filter_mode() == FilterMode::Nearest);
+}


### PR DESCRIPTION
The move constructor and the move assignment operator would not even compile :sweat:
This PR fixes both methods and adds rudimentary tests cases which should at least guarantee that they compile.