### PR TITLE
Cubic bspline hessian matrix & resolution update

### DIFF
--- a/src/python/texture.h
+++ b/src/python/texture.h
@@ -32,6 +32,7 @@ void bind_texture(py::module &m, const char *name) {
         .def("eval_enoki", &Tex::eval_enoki, "pos"_a, "active"_a = true)
         .def("eval_cubic", &Tex::eval_cubic, "pos"_a, "active"_a = true, "force_enoki"_a = false)
         .def("eval_cubic_grad", &Tex::eval_cubic_grad, "pos"_a, "active"_a = true)
+        .def("eval_cubic_hessian", &Tex::eval_cubic_hessian, "pos"_a, "active"_a = true)
         .def("eval", &Tex::eval, "pos"_a, "active"_a = true);
 
     tex.attr("IsTexture") = true;


### PR DESCRIPTION
Simple implementation of `eval_cubic_hessian()`.
Compatible with Nicolas's changes about wrapping mode and others.

- It returns **both positional "gradient" and "hessian"**. 
They have quite some common computation. But consequently there is no interface to compute only the "hessian".
The return type is a ~`std::tuple`~`std::pair`.

- Now all the gradients/hessian return value has **the volume resolution** multiplied.
Prior to this PR, we assume the volume has unit size (because the query point is in [0, 1]^d). I need to manually multiply the shape with the returned "gradient" in my volume optimization.
But this becomes too complicated for "hessian" matrix, where each cell needs a different multiplier. So I moved this "unit size -> volume shape transformation" jacobian inside.
This change applies to the explicit gradient computation, explicit hessian computation, and implicit AD gradient computation. 