### PR TITLE
Texture: add support for N-channel textures

### DIFF
--- a/src/python/texture.h
+++ b/src/python/texture.h
@@ -28,12 +28,63 @@ void bind_texture(py::module &m, const char *name) {
         .def("tensor", &Tex::tensor, py::return_value_policy::reference_internal)
         .def("filter_mode", &Tex::filter_mode)
         .def("wrap_mode", &Tex::wrap_mode)
-        .def("eval_cuda", &Tex::eval_cuda, "pos"_a, "active"_a = true)
-        .def("eval_enoki", &Tex::eval_enoki, "pos"_a, "active"_a = true)
-        .def("eval_cubic", &Tex::eval_cubic, "pos"_a, "active"_a = true, "force_enoki"_a = false)
-        .def("eval_cubic_grad", &Tex::eval_cubic_grad, "pos"_a, "active"_a = true)
-        .def("eval_cubic_hessian", &Tex::eval_cubic_hessian, "pos"_a, "active"_a = true)
-        .def("eval", &Tex::eval, "pos"_a, "active"_a = true);
+        .def("eval_cuda",
+                [](const Tex &texture, const ek::Array<Type, Dimension> &pos,
+                   const ek::mask_t<Type> active) {
+                    size_t channels = texture.shape()[Dimension];
+                    std::vector<Type> result(channels);
+                    texture.eval_cuda(pos, result.data(), active);
+
+                    return result;
+                }, "pos"_a, "active"_a = true)
+        .def("eval_enoki",
+                [](const Tex &texture, const ek::Array<Type, Dimension> &pos,
+                   const ek::mask_t<Type> active) {
+                    size_t channels = texture.shape()[Dimension];
+                    std::vector<Type> result(channels);
+                    texture.eval_enoki(pos, result.data(), active);
+
+                    return result;
+                }, "pos"_a, "active"_a = true)
+        .def("eval_cubic",
+                [](const Tex &texture, const ek::Array<Type, Dimension> &pos,
+                   const ek::mask_t<Type> active, bool force_enoki) {
+                    size_t channels = texture.shape()[Dimension];
+                    std::vector<Type> result(channels);
+                    texture.eval_cubic(pos, result.data(), active, force_enoki);
+
+                    return result;
+                }, "pos"_a, "active"_a = true, "force_enoki"_a = false)
+        .def("eval_cubic_grad",
+                [](const Tex &texture, const ek::Array<Type, Dimension> &pos,
+                   const ek::mask_t<Type> active) {
+
+                    size_t channels = texture.shape()[Dimension];
+                    std::vector<ek::Array<Type, Dimension>> result(channels);
+                    texture.eval_cubic_grad(pos, result.data(), active);
+
+                    return result;
+                }, "pos"_a, "active"_a = true)
+        .def("eval_cubic_hessian",
+                [](const Tex &texture, const ek::Array<Type, Dimension> &pos,
+                   const ek::mask_t<Type> active) {
+                    size_t channels = texture.shape()[Dimension];
+                    std::vector<ek::Array<Type, Dimension>> gradient(channels);
+                    std::vector<ek::Matrix<Type, Dimension>> hessian(channels);
+                    texture.eval_cubic_hessian(pos, gradient.data(),
+                                               hessian.data(), active);
+
+                    return std::make_tuple(gradient, hessian);
+                }, "pos"_a, "active"_a = true)
+        .def("eval",
+                [](const Tex &texture, const ek::Array<Type, Dimension> &pos,
+                   const ek::mask_t<Type> active) {
+                    size_t channels = texture.shape()[Dimension];
+                    std::vector<Type> result(channels);
+                    texture.eval(pos, result.data(), active);
+
+                    return result;
+                }, "pos"_a, "active"_a = true);
 
     tex.attr("IsTexture") = true;
 }


### PR DESCRIPTION
With this PR `enoki::Texture` can now handle textures with an arbitrary number of channels.

All evaluation interfaces were changed, they now take an output parameter that is used to write the evaluation's result to. The python bindings for the evaluation methods still directly return the result, however these are now returned as python list of length N for a N-channel texture.

Tests were added to cover the new interfaces and verify the underlying implementation in `enoki-jit` when using CUDA texture objects.

:warning: This PR is already rebased on Ziyi's work in https://github.com/wjakob/enoki/pull/23 (not merged yet).
