### PR TITLE
Include AVX-512 popcnt headers

### DIFF
--- a/include/drjit/packet_intrin.h
+++ b/include/drjit/packet_intrin.h
@@ -64,6 +64,14 @@
 #    include <avx512dqintrin.h>
 #    include <avx512vldqintrin.h>
 #    include <avx512vlbwintrin.h>
+#    if defined(DRJIT_X86_AVX512VPOPCNTDQ)
+#        include <avx512vpopcntdqintrin.h>
+#        include <avx512vpopcntdqvlintrin.h>
+#    endif
+#    if defined(DRJIT_X86_AVX512VBMI)
+#        include <avx512vbmiintrin.h>
+#        include <avx512vbmivlintrin.h>
+#    endif
 #    if defined(__clang__)
 #      include <avx512vlcdintrin.h>
 #    endif


### PR DESCRIPTION
Fix for inclusion of popcnt intrinsics in `packet_intrin.h` where avx512 headers are included. Specifically, while the `__mm512_popcnt_epi*` intrinsic is referenced in https://github.com/mitsuba-renderer/drjit/blob/c0808251b6f775895965405b4f01cb31ee66f2c3/include/drjit/packet_avx512.h#L846-L848 the corresponding headers for it are not included in https://github.com/mitsuba-renderer/drjit/blob/c0808251b6f775895965405b4f01cb31ee66f2c3/include/drjit/packet_intrin.h#L59-L70 leading to a compilation failure due to the missing references.

This fix simply adds the header inclusions based on the `DRJIT_X86_AVX512` defines.