### PR TITLE
Change migrate behavior in Texture class

### DIFF
--- a/drjit/tensor.py
+++ b/drjit/tensor.py
@@ -119,7 +119,6 @@ def upsample(t, shape=None, scale_factor=None):
         # Create the up-sampled texture
         texture = type(t)(shape[:-1], channels,
                           use_accel=t.use_accel(),
-                          migrate=t.migrate(),
                           filter_mode=t.filter_mode(),
                           wrap_mode=t.wrap_mode())
         texture.set_value(data)

--- a/src/python/texture.h
+++ b/src/python/texture.h
@@ -9,21 +9,20 @@ void bind_texture(py::module &m, const char *name) {
 
     auto tex = py::class_<Tex>(m, name)
         .def(py::init([](const std::array<size_t, Dimension> &shape,
-                         size_t channels, bool use_accel, bool migrate,
+                         size_t channels, bool use_accel,
                          dr::FilterMode filter_mode, dr::WrapMode wrap_mode) {
-                 return new Tex(shape.data(), channels, use_accel, migrate,
-                                filter_mode, wrap_mode);
+                 return new Tex(shape.data(), channels, use_accel, filter_mode, wrap_mode);
              }),
-             "shape"_a, "channels"_a, "use_accel"_a=true, "migrate"_a = true,
+             "shape"_a, "channels"_a, "use_accel"_a = true,
              "filter_mode"_a = dr::FilterMode::Linear,
              "wrap_mode"_a = dr::WrapMode::Clamp)
         .def(py::init<const typename Tex::TensorXf &, bool, bool, dr::FilterMode,
                       dr::WrapMode>(),
-             "tensor"_a, "use_accel"_a=true, "migrate"_a = true,
+             "tensor"_a, "use_accel"_a = true, "migrate"_a = true,
              "filter_mode"_a = dr::FilterMode::Linear,
              "wrap_mode"_a = dr::WrapMode::Clamp)
-        .def("set_value", &Tex::set_value, "value"_a)
-        .def("set_tensor", &Tex::set_tensor, "tensor"_a)
+        .def("set_value",  &Tex::set_value,  "value"_a,  "migrate"_a = false)
+        .def("set_tensor", &Tex::set_tensor, "tensor"_a, "migrate"_a = false)
         .def("value", &Tex::value, py::return_value_policy::reference_internal)
         .def("tensor",
              py::overload_cast<>(&Tex::tensor, py::const_),
@@ -31,7 +30,7 @@ void bind_texture(py::module &m, const char *name) {
         .def("filter_mode", &Tex::filter_mode)
         .def("wrap_mode", &Tex::wrap_mode)
         .def("use_accel", &Tex::use_accel)
-        .def("migrate", &Tex::migrate)
+        .def("migrated", &Tex::migrated)
         .def_property_readonly("shape", [](const Tex &t) {
             PyObject *shape = PyTuple_New(t.ndim());
             for (size_t i = 0; i < t.ndim(); ++i)
@@ -47,7 +46,7 @@ void bind_texture(py::module &m, const char *name) {
 
                     return result;
                 }, "pos"_a, "active"_a = true)
-        .def("eval_drjit",
+        .def("eval_nonaccel",
                 [](const Tex &texture, const dr::Array<Type, Dimension> &pos,
                    const dr::mask_t<Type> active) {
                     size_t channels = texture.shape()[Dimension];


### PR DESCRIPTION
This PR changes the behavior of the migration feature of the `dr::Texture` class.

It is now specified explicitly at construction and when setting a new value/tensor whether the texture data should be fully migrated to the GPU (when `use_accel==True`).

This was causing issues when the texture data was accessed by reference and later updated.