### PR TITLE
CustomOp: more flexibility on input & output types

### DIFF
--- a/drjit/router.py
+++ b/drjit/router.py
@@ -3943,10 +3943,15 @@ def grad(arg, preserve_type=True):
         object: the gradient value associated to the input variable.
     '''
     if _dr.is_diff_v(arg):
-        if preserve_type:
-            return type(arg)(arg.grad_())
+        if _dr.is_integral_v(arg):
+            grads = _dr.zeros(_dr.detached_t(type(arg)))
         else:
-            return arg.grad_()
+            grads = arg.grad_()
+
+        if preserve_type:
+            return type(arg)(grads)
+        else:
+            return grads
     elif _dr.is_struct_v(arg):
         result = type(arg)()
         if not preserve_type:
@@ -5568,7 +5573,7 @@ def custom(cls, *args, **kwargs):
     _dr.detail.diff_vars(inst._implicit_in, diff_vars_in)
 
     if len(diff_vars_in) > 0:
-        output = _dr.diff_array_t(output)
+        output = _dr.diff_array_t(output, allow_non_array=True)
         Type = _dr.leaf_array_t(output)
         tmp_in, tmp_out = Type(), Type()
         _dr.enable_grad(tmp_in, tmp_out, output)

--- a/drjit/traits.py
+++ b/drjit/traits.py
@@ -696,7 +696,7 @@ def float64_array_t(arg):
     return arg.ReplaceScalar(VarType.Float64) if is_array_v(arg) else float
 
 
-def diff_array_t(a):
+def diff_array_t(a, allow_non_array=False):
     '''
     Converts the provided Dr.Jit array/tensor type into a differentiable version.
 
@@ -705,7 +705,7 @@ def diff_array_t(a):
     1. When invoked with a Dr.Jit array *type* (e.g. :py:class:`drjit.cuda.Array3f`), it
        returns a *differentiable* version (e.g. :py:class:`drjit.cuda.ad.Array3f`).
 
-    2. When the input isn't a type, it returns ``diff_array_t(type(arg))``.
+    2. When the input isn't a type, it returns ``diff_array_t(type(arg))(arg)``.
 
     3. When the input is is a list or a tuple, it recursively call ``diff_array_t`` over all elements.
 
@@ -718,13 +718,16 @@ def diff_array_t(a):
         type: Result of the conversion as described above.
     '''
     if isinstance(a, tuple):
-        return tuple(diff_array_t(v) for v in a)
+        return tuple(diff_array_t(v, allow_non_array=allow_non_array)
+                     for v in a)
     elif isinstance(a, list):
         return [diff_array_t(v) for v in a]
     elif not is_array_v(a):
+        if allow_non_array:
+            return a
         raise Exception("diff_array_t(): requires an Dr.Jit input array!")
     elif not isinstance(a, type):
-        return diff_array_t(type(a))(a)
+        return diff_array_t(type(a), allow_non_array=allow_non_array)(a)
     elif a.IsDiff:
         return a
     else:


### PR DESCRIPTION
`CustomOp` would not fully handle non-array inputs or outputs.
There were also issues with integral types (e.g. `ad.UInt32`), which could be detected as differentiable but did not actually have gradients.