### PR TITLE
Fix android 32-bit build errors

### DIFF
--- a/include/drjit/array.h
+++ b/include/drjit/array.h
@@ -28,6 +28,9 @@
 #include <cstdint>
 
 // Core C++ headers needed by Dr.Jit
+#if defined(__ANDROID__)
+#  include <cmath>
+#endif
 // On libc++, include <utility> without pulling in the entire C/C++ math library
 #if defined(_LIBCPP_CMATH) || !defined(_LIBCPP_VERSION)
 #  include <utility>

--- a/include/drjit/packet_neon.h
+++ b/include/drjit/packet_neon.h
@@ -13,7 +13,12 @@
 #pragma once
 
 NAMESPACE_BEGIN(drjit)
-DRJIT_PACKET_DECLARE(16)
+DRJIT_PACKET_DECLARE_COND(16, enable_if_t<(std::is_same_v<Type, float>)>)
+DRJIT_PACKET_DECLARE_COND(16, enable_if_int32_t<Type>)
+#if defined(DRJIT_ARM_64)
+DRJIT_PACKET_DECLARE_COND(16, enable_if_t<(std::is_same_v<Type, double>)>)
+DRJIT_PACKET_DECLARE_COND(16, enable_if_int64_t<Type>)
+#endif
 DRJIT_PACKET_DECLARE(12)
 
 NAMESPACE_BEGIN(detail)


### PR DESCRIPTION
I noticed that building for Android 32-bit was resulting in errors. It seems that the issue was due to a missing `<cmath>` include and some packet definitions that weren't being conditionally compiled.

This PR depends on https://github.com/mitsuba-renderer/drjit-core/pull/143