### PR TITLE
Fix C++ transform_compose function

### DIFF
--- a/include/drjit/transform.h
+++ b/include/drjit/transform.h
@@ -22,9 +22,10 @@ Matrix translate(const Array<entry_t<Matrix>, size_v<Matrix> - 1> &v) {
     size_t N = size_v<Matrix>;
     Matrix trafo = identity<Matrix>();
     for (size_t i = 0; i < N - 1; ++i)
-        trafo(N - 1, i) = v.entry(i);
+        trafo(i, N - 1) = v.entry(i);
     trafo(N - 1, N - 1) = 1;
-    return transpose(trafo);
+
+    return trafo;
 }
 
 template <typename Matrix>
@@ -200,12 +201,13 @@ Matrix4 transform_compose(const Matrix<entry_t<Matrix4>, 3> &s,
         "Matrix::transform_compose(): template argument must be of type Matrix<T, 4>");
 
     using Value = entry_t<Matrix4>;
-    Matrix3 m33(quat_to_matrix<Matrix<Value, 3>>(q) * s);
-    return Matrix4(
-        m33[0][0], m33[0][1], m33[0][2], t[0],
-        m33[1][0], m33[1][1], m33[1][2], t[1],
-        m33[2][0], m33[2][1], m33[2][2], t[2],
-        0, 0, 0, 0);
+
+    Matrix4 result(quat_to_matrix<Matrix<Value, 3>>(q) * s);
+    for (size_t i = 0; i < 3; ++i)
+        result(i, 3) = t.entry(i);
+    result(3, 3) = 1;
+
+    return result;
 }
 
 template <typename Matrix4>
@@ -219,7 +221,11 @@ Matrix4 transform_compose_inverse(const Matrix<entry_t<Matrix4>, 3> &s,
     using Value = entry_t<Matrix4>;
     Matrix<Value, 3> inv_m = inverse(quat_to_matrix<Matrix<Value, 3>>(q) * s);
     Matrix4 result(inv_m);
-    result.entry(3) = concat(inv_m * -t, Array<Value, 1>(1));
+    auto tmp = inv_m * -t;
+    for (size_t i = 0; i < 3; ++i)
+        result(i, 3) = tmp.entry(i);
+    result(3, 3) = 1;
+
     return result;
 }
 

--- a/tests/py_cpp_consistency_ext.cpp
+++ b/tests/py_cpp_consistency_ext.cpp
@@ -2,6 +2,9 @@
 #include <drjit/python.h>
 #include <drjit/autodiff.h>
 #include <drjit/packet.h>
+#include <drjit/matrix.h>
+#include <drjit/transform.h>
+#include <nanobind/stl/tuple.h>
 
 namespace nb = nanobind;
 namespace dr = drjit;
@@ -16,11 +19,34 @@ Float repeat(const Float &source, uint32_t count) {
     return Float::steal(jit_var_repeat(source.index(), count));
 }
 
+template <typename Matrix4, typename Matrix3, typename Quaternion, typename Array>
+std::tuple<Matrix3, Quaternion, Array> transform_decompose(Matrix4 m) {
+    auto [s, q, t] = dr::transform_decompose(m);
+    return std::make_tuple(s, q, t);
+}
+
+template <typename Matrix4, typename Matrix3, typename Quaternion, typename Array>
+Matrix4 transform_compose(Matrix3 m, Quaternion q, Array tr) {
+    return dr::transform_compose<Matrix4>(m, q, tr);
+}
+
+template <typename Matrix4, typename Array>
+Matrix4 translate(Array tr) {
+    return dr::translate<Matrix4>(tr);
+}
+
 template <JitBackend Backend> void bind(nb::module_ &m) {
     using Float = dr::DiffArray<Backend, float>;
+    using Matrix4f = dr::Matrix<dr::DiffArray<Backend, float>, 4>;
+    using Matrix3f = dr::Matrix<dr::DiffArray<Backend, float>, 3>;
+    using Quaternion4f = dr::Quaternion<dr::DiffArray<Backend, float>>;
+    using Array3f = dr::Array<dr::DiffArray<Backend, float>, 3>;
 
     m.def("tile", &tile<Float>);
     m.def("repeat", &repeat<Float>);
+    m.def("transform_decompose", &transform_decompose<Matrix4f, Matrix3f, Quaternion4f, Array3f>);
+    m.def("transform_compose", &transform_compose<Matrix4f, Matrix3f, Quaternion4f, Array3f>);
+    m.def("translate", &translate<Matrix4f, Array3f>);
 }
 
 NB_MODULE(py_cpp_consistency_ext, m) {


### PR DESCRIPTION
The C++ compose_transform function has a small bug. The translation is set in the last row of the matrix, rather than the last column as it should be. This PR fixes this by directly building the 4x4 matrix with the right entries.

I tested this code in my use case and it works, but there are no unit tests (for the entire file) at the moment.