### PR TITLE
Fix spurious warning when freezing functions with very wide literals

### DIFF
--- a/src/python/freeze.cpp
+++ b/src/python/freeze.cpp
@@ -1627,12 +1627,15 @@ size_t FlatVariablesHasher::operator()(
                     "The layout consists of more than 100M elements, which "
                     "might lead to hash collisions when looking up previous "
                     "recordings of frozen functions.");
-        if (layout_.index >> 26)
+        if (layout_.index >> 26 &&
+            !(layout_.flags & ((uint32_t) LayoutFlag::Undefined |
+                               (uint32_t) LayoutFlag::Literal))) {
             jit_log(
                 LogLevel::Warn,
                 "The layout consists of more than 100M opaque variables, which "
                 "might lead to hash collisions when looking up previous "
                 "recordings of frozen functions.");
+        }
         union {
             struct {
                 uint64_t num : 26;

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -2925,7 +2925,7 @@ def test74_auto_opaque_retraverse(t):
 @pytest.mark.parametrize("auto_opaque", [False, True])
 def test75_changing_literal_width(t, auto_opaque):
     """
-    Tests that the auot opaque feature correctly forces evaluation of literals,
+    Tests that the auto opaque feature correctly forces evaluation of literals,
     if the literal size changes between calls to the frozen function.
     """
 


### PR DESCRIPTION
This PR fixes a spurious warning.

Reproducer:
```python
import drjit as dr
from drjit.auto import TensorXf

@dr.freeze
def f(tensor):
    return tensor + 1
a = dr.zeros(TensorXf, shape=(100_000_000, 1))
f(a)
```