### PR TITLE
Remove argument in dr.sync_thread()

### DIFF
--- a/docs/bench.rst
+++ b/docs/bench.rst
@@ -36,7 +36,7 @@ we could add a call to :py:func:`dr.sync_thread()`.
    start = time.end()
    y = f(x)
    dr.eval(y)
-   dr.sync_thread(y)
+   dr.sync_thread()
    end = time.end()
 
 However, explicit synchronization is generally an *anti-pattern* and not


### PR DESCRIPTION
When running the doc, interpreter shows:

```
E       TypeError: sync_thread(): incompatible function arguments. The following argument types are supported:
E           1. sync_thread() -> None
```

According to API doc, it does not take any argument.