### PR TITLE
Advanced Tensor Indexing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -102,6 +102,13 @@ DrJit 1.4.0 (TBA)
   reverse mode via trajectory replay. See the
   :ref:`documentation <diff_loops>` for details.
 
+- **NumPy-style advanced tensor indexing**: Tensor indexing with multiple
+  integer arrays now follows NumPy/PyTorch semantics. Previously,
+  ``t[arr1, arr2]`` selected all combinations (a grid); it now selects
+  element-wise pairs, matching ``torch`` and ``numpy`` behavior. Non-consecutive
+  array indices (e.g., ``t[arr, :, arr]``) correctly broadcast and move the
+  result dimension to the front of the output shape.
+
 - **NumPy-style array/tensor manipulation and sorting**: This release brings a
   large set NumPy-compatible functions for sorting, reshaping, and reindexing
   arrays and tensors. This includes :py:func:`dr.sort() <sort>`,

--- a/docs/freeze.rst
+++ b/docs/freeze.rst
@@ -630,36 +630,48 @@ possible to reuse the same code as long as trailing dimensions do not change.
    func(t, UInt(1), UInt(1), UInt(1))
 
 Dr.Jit also supports advanced tensor indexing, allowing you to use arrays to
-index into a tensor e.g. ``t[UInt(1, 2, 3), :]``. This syntax can also be
-used inside of frozen functions, however it might lead to kernels with baked-in
-kernel sizes, and therefore incorrect outputs. If tensor indexing with indices
-of changing sizes is required, calculating the array index manually with the
-formula in the above example is recommended.
+index into a tensor e.g. ``t[UInt(1, 2, 3), :]``. When multiple array indices
+are used, they select element-wise following NumPy/PyTorch semantics (all
+arrays must have the same length or length 1 for broadcasting). This syntax
+can also be used inside of frozen functions, however it might lead to kernels
+with baked-in kernel sizes, and therefore incorrect outputs. If tensor indexing
+with indices of changing sizes is required, calculating the array index
+manually with the formula in the above example is recommended.
 
 .. code-block:: python
 
    @dr.freeze
    def func(t: TensorXf, i: UInt, j: UInt, k: UInt):
-      # Indexes into the tensor array, getting the entry at (row, col)
+      # Indexes into the tensor array, getting the entry at (i, j, k)
       return t[i, j, k]
 
    t = TensorXf(dr.arange(Float, 10*7*3), shape=(10, 7, 3))
 
    # The first call will record the function, and will return a tensor of shape
-   # (3, 2, 1)
-   func(t, UInt(1, 2, 3), UInt(1, 2), UInt(1))
+   # (3,)
+   func(t, UInt(1, 2, 3), UInt(1, 2, 3), UInt(1, 2, 3))
 
    # Calling the function with a different number of index elements will be
-   # correct, as long as only the array with the largest number of indices
-   # changes.
-   func(t, UInt(1, 2, 3, 4), UInt(1, 2), UInt(1))
+   # correct, as long as only array indices are used (no slices).
+   func(t, UInt(1, 2, 3, 4), UInt(1, 2, 3, 4), UInt(1, 2, 3, 4))
 
-   # Calling the function with a different number of index elements on multiple
-   # dimensions can lead  to incorrect outputs. The heuristic will use the larger
-   # array to infer the size of the kernel, by multiplication with the recorded
-   # fraction (in this case 2). This call will (incorrectly) return a tensor of
-   # shape (4, 2, 1).
-   func(t, UInt(1, 2, 3, 4), UInt(1, 2, 3), UInt(1))
+   # Mixing array indices with slice dimensions can lead to incorrect outputs
+   # when the tensor data size happens to be a multiple of the kernel launch
+   # size. The heuristic will infer the kernel size from the tensor data
+   # pointer instead of the array indices.
+
+   @dr.freeze
+   def func2(t: TensorXf, row: UInt):
+      return t[row, :]
+
+   t2 = TensorXf(dr.arange(Float, 10*10*3), shape=(10, 10, 3))
+
+   # This call records the kernel with array size 2 (launch size 2*30=60,
+   # and tensor size 300 is a multiple of 60)
+   func2(t2, UInt(0, 1))
+
+   # This call will (incorrectly) replay with the old kernel size
+   func2(t2, UInt(0, 1, 2))
 
 
 .. warning::

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -573,6 +573,16 @@ indexing with :py:attr:`drjit.newaxis` (or equivalently, ``None``).
    >>> t2.shape
    (2, 3, 1, 40)
 
+When multiple integer arrays are used in the slicing operation, they follow NumPy/PyTorch
+advanced indexing semantics: the arrays are broadcast together and select
+element-wise, producing a single output dimension instead of a grid.
+
+.. code-block:: pycon
+
+   >>> t = TensorXf(dr.arange(Float, 16), shape=(4, 4))
+   >>> t[UInt32(0, 2), UInt32(0, 2)]
+   [0, 10]
+
 Slicing internally turns into a :py:func:`drjit.gather` operation that reads
 from the underlying flat array, while slice assignment turns into
 :py:func:`drjit.scatter`. The conversion from a slice tuple into concrete

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -2876,7 +2876,9 @@
     tuple. For example, ``[5:10:2, ..., None]`` would be specified as ``(slice(5,
     10, 2), Ellipsis, None)``.
 
-    An example is shown below:
+    When multiple integer arrays appear in the indices, they follow NumPy/PyTorch
+    advanced indexing semantics: the arrays are broadcast together and select
+    element-wise, producing a single output dimension.
 
     .. code-block:: pycon
 

--- a/src/python/slice.cpp
+++ b/src/python/slice.cpp
@@ -17,19 +17,28 @@
 #include "base.h"
 #include "slice.h"
 #include "meta.h"
+#include <algorithm>
 #include <vector>
 
 /// Holds metadata about slicing component
 struct Component {
+    enum Type { None, Integer, Slice, Advanced };
+
+    Type type;
     Py_ssize_t start, step, slice_size, size;
     nb::object object;
 
-    Component(Py_ssize_t start, Py_ssize_t step, Py_ssize_t slice_size,
-              Py_ssize_t size)
-        : start(start), step(step), slice_size(slice_size), size(size) { }
+    Component(Type t)
+        : type(t), start(0), step(1), slice_size(1), size(1) { }
 
-    Component(nb::handle h, Py_ssize_t slice_size, Py_ssize_t size)
-        : start(0), step(1), slice_size(slice_size), size(size),
+    Component(Type t, Py_ssize_t start, Py_ssize_t step,
+              Py_ssize_t slice_size, Py_ssize_t size)
+        : type(t), start(start), step(step),
+          slice_size(slice_size), size(size) { }
+
+    Component(Type t, nb::handle h, Py_ssize_t slice_size,
+              Py_ssize_t size)
+        : type(t), start(0), step(1), slice_size(slice_size), size(size),
           object(nb::borrow(h)) { }
 };
 
@@ -72,11 +81,13 @@ slice_index(const nb::type_object_t<ArrayBase> &dtype,
            indices_len = nb::len(indices);
 
     std::vector<Component> components;
-    components.reserve(shape_len);
+    components.reserve(indices_len);
+
+    size_t advanced_size = 0;
 
     for (nb::handle h : indices) {
         if (h.is_none()) {
-            shape_out.append(1);
+            components.emplace_back(Component::None);
             continue;
         }
 
@@ -96,15 +107,13 @@ slice_index(const nb::type_object_t<ArrayBase> &dtype,
                           "bounds for axis %zu with size %zd.",
                           v, components.size(), size);
 
-            components.emplace_back(v, 1, 1, size);
+            components.emplace_back(Component::Integer, v, 1, 1, size);
             continue;
         } else if (tp.is(&PySlice_Type)) {
             Py_ssize_t start, stop, step;
             size_t slice_length;
             nb::detail::slice_compute(h.ptr(), size, start, stop, step, slice_length);
-            components.emplace_back(start, step, (Py_ssize_t) slice_length, size);
-            shape_out.append(slice_length);
-            size_out *= slice_length;
+            components.emplace_back(Component::Slice, start, step, (Py_ssize_t) slice_length, size);
             continue;
         } else if (is_drjit_type(tp)) {
             const ArraySupplement *s2 = &supp(tp);
@@ -138,9 +147,18 @@ slice_index(const nb::type_object_t<ArrayBase> &dtype,
                 if (!o.type().is(dtype))
                     o = dtype(o);
 
-                components.emplace_back(o, slice_size, size);
-                shape_out.append(slice_size);
-                size_out *= slice_size;
+                components.emplace_back(Component::Advanced, o, slice_size, size);
+
+                if (advanced_size == 0)
+                    advanced_size = slice_size;
+                else if (slice_size != 1 && advanced_size != 1 &&
+                         advanced_size != slice_size)
+                    nb::raise("drjit.slice_index(): advanced index arrays "
+                              "with shapes %zu and %zu cannot be broadcast "
+                              "together.", advanced_size, slice_size);
+                else if (slice_size > advanced_size)
+                    advanced_size = slice_size;
+
                 continue;
             }
         } else if (tp.is(&PyEllipsis_Type)) {
@@ -151,9 +169,7 @@ slice_index(const nb::type_object_t<ArrayBase> &dtype,
                 if (shape_offset >= shape_len)
                     nb::detail::fail("slice_index(): internal error.");
                 size = nb::cast<Py_ssize_t>(shape[shape_offset++]);
-                components.emplace_back(0, 1, size, size);
-                shape_out.append(size);
-                size_out *= size;
+                components.emplace_back(Component::Slice, 0, 1, size, size);
             }
             continue;
         }
@@ -167,10 +183,45 @@ slice_index(const nb::type_object_t<ArrayBase> &dtype,
     // Implicit ellipsis at the end
     while (shape_offset != shape_len) {
         Py_ssize_t size = nb::cast<Py_ssize_t>(shape[shape_offset++]);
-        components.emplace_back(0, 1, size, size);
-        shape_out.append(size);
-        size_out *= size;
+        components.emplace_back(Component::Slice, 0, 1, size, size);
     }
+
+    // Build output shape following PyTorch/NumPy advanced indexing
+    // rules: consecutive advanced indices produce a single dimension
+    // in place; non-consecutive ones move it to the front.
+    shape_out.clear();
+
+    bool has_advanced = false, consecutive = true, in_gap = false;
+    for (const auto &c : components) {
+        if (c.type == Component::Advanced) {
+            if (in_gap) consecutive = false;
+            has_advanced = true;
+            in_gap = false;
+        } else if (has_advanced &&
+                   (c.type == Component::Slice || c.type == Component::None)) {
+            in_gap = true;
+        }
+    }
+
+    bool advanced_added = false;
+    if (has_advanced && !consecutive) {
+        advanced_added = true;
+        shape_out.append(advanced_size);
+    }
+    for (const auto &c : components) {
+        if (c.type == Component::None)
+            shape_out.append(1);
+        else if (c.type == Component::Slice)
+            shape_out.append(c.slice_size);
+        else if (c.type == Component::Advanced && !advanced_added) {
+            advanced_added = true;
+            shape_out.append(advanced_size);
+        }
+    }
+
+    size_out = 1;
+    for (nb::handle h : shape_out)
+        size_out *= nb::cast<size_t>(h);
 
     if (size_out == 0)
         return { nb::tuple(shape_out), dtype() };
@@ -181,9 +232,10 @@ slice_index(const nb::type_object_t<ArrayBase> &dtype,
     // passthrough axes a slab of the linear output index maps directly
     // to the input. Coalesce each run into one synthetic axis so the
     // main loop below handles it as one ordinary iteration.
+    // shape_out is not affected.
     auto is_passthrough = [](const Component &c) {
-        return !c.object.is_valid() && c.start == 0 && c.step == 1 &&
-               c.slice_size == c.size;
+        return c.type == Component::Slice && c.start == 0 &&
+               c.step == 1 && c.slice_size == c.size;
     };
     {
         size_t out = 0;
@@ -194,11 +246,11 @@ slice_index(const nb::type_object_t<ArrayBase> &dtype,
                 ++out; ++k;
                 continue;
             }
-            size_t run_size = 1;
+            Py_ssize_t run_size = 1;
             while (k < components.size() && is_passthrough(components[k]))
                 run_size *= components[k++].size;
-            components[out++] = Component(0, 1, (Py_ssize_t) run_size,
-                                          (Py_ssize_t) run_size);
+            components[out++] = Component(
+                Component::Slice, 0, 1, run_size, run_size);
         }
         components.erase(components.begin() + out, components.end());
     }
@@ -206,16 +258,16 @@ slice_index(const nb::type_object_t<ArrayBase> &dtype,
     // A "skippable" axis has output size 1 *and* a fixed input position,
     // so its contribution is a single constant we fold into `base`. Two
     // forms qualify: a literal integer index `t[i]`, and a `:` slice on
-    // a size-1 input dim. (An index-array `t[arr]` with len(arr) == 1
-    // also has output size 1, but reads `arr[0]` at runtime, so it
-    // requires a gather and is NOT skippable.)
+    // a size-1 input dim. (An array index with len==1 also has output
+    // size 1, but reads arr[0] at runtime, so it is NOT skippable.)
     auto is_skippable = [](const Component &c) {
-        return !c.object.is_valid() && c.slice_size == 1;
+        return c.type == Component::Integer ||
+               (c.type == Component::Slice && c.slice_size == 1);
     };
 
     // Walk `components` once to compute:
     //   `base`  -- the total constant input offset, summing
-    //              `start * input_stride` over every non-gather axis.
+    //              `start * in_stride` over every non-Advanced axis.
     //              Seeded into `index_out` so the main loop's per-axis
     //              fma absorbs it for free (one fewer add per axis).
     //   `first` -- index of the outermost non-skippable axis. The main
@@ -226,7 +278,8 @@ slice_index(const nb::type_object_t<ArrayBase> &dtype,
     size_t in_stride = 1, first = components.size();
     for (size_t k = components.size(); k-- > 0;) {
         const Component &c = components[k];
-        if (!c.object.is_valid())
+        if (c.type == Component::None) continue;
+        if (c.type != Component::Advanced)
             base += uint32_t(c.start * in_stride);
         if (!is_skippable(c))
             first = k;
@@ -237,14 +290,45 @@ slice_index(const nb::type_object_t<ArrayBase> &dtype,
     nb::object active = nb::borrow(Py_True);
     nb::object index_out = dtype(base);
 
+    // Pre-extract the advanced index before the main loop.
+    nb::object advanced_idx;
+    if (has_advanced && size_out == advanced_size) {
+        // Advanced dim is the only output dim.
+        advanced_idx = index;
+    } else if (has_advanced && !consecutive) {
+        // Non-consecutive: advanced dim is outermost.
+        size_t rest_size = size_out / advanced_size;
+        advanced_idx = index.floor_div(dtype(rest_size));
+        index = fma(advanced_idx, dtype(uint32_t(-rest_size)), index);
+    }
+
     // Process axes from innermost to outermost, peeling one output
     // coordinate off `index` at each step.
     in_stride = 1;
     for (size_t k = components.size(); k-- > first;) {
         const Component &c = components[k];
+        if (c.type == Component::None) continue;
         if (!is_skippable(c)) {
             nb::object rem;
-            if (k == first) {
+            if (has_advanced && c.type == Component::Advanced) {
+                // All advanced components share one output dim.
+                // For consecutive, the first one peels; the rest reuse.
+                if (!advanced_idx.is_valid()) {
+                    if (k == first ||
+                        components[first].type == Component::Advanced) {
+                        // No more Slice dims to peel — index already
+                        // holds the advanced coordinate.
+                        advanced_idx = std::move(index);
+                    } else {
+                        nb::object next =
+                            index.floor_div(dtype(advanced_size));
+                        advanced_idx = fma(
+                            next, dtype(uint32_t(-advanced_size)), index);
+                        index = std::move(next);
+                    }
+                }
+                rem = (c.slice_size == 1) ? dtype(0) : advanced_idx;
+            } else if (k == first) {
                 rem = std::move(index);
             } else {
                 nb::object next = index.floor_div(dtype(c.slice_size));
@@ -253,10 +337,10 @@ slice_index(const nb::type_object_t<ArrayBase> &dtype,
             }
 
             // Add this axis's contribution to the input linear index:
-            //   slice:  (step * rem) * in_stride   (start * in_stride is in `base`)
-            //   gather: arr[rem]    * in_stride
+            //   slice:    (step * rem) * in_stride   (start * in_stride is in `base`)
+            //   advanced: gather(arr, rem) * in_stride
             uint32_t coef = uint32_t(in_stride);
-            if (c.object.is_valid())
+            if (c.type == Component::Advanced)
                 rem = gather(dtype, c.object, rem, active, ReduceMode::Auto);
             else
                 coef *= uint32_t(c.step);

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -3427,13 +3427,12 @@ def test90_tensor_slicing(t, auto_opaque):
 
     frozen = dr.freeze(func, auto_opaque=auto_opaque)
 
-    for i in range(3):
+    for i in range(4):
         shape = ((i + 5), 10)
         x = mod.TensorXf(dr.arange(mod.Float, dr.prod(shape)), shape=shape)
         # Both row and col must have the same length for advanced indexing
-        n = 3
-        row = dr.arange(mod.UInt32, n)
-        col = dr.arange(mod.UInt32, n) + 1
+        row = dr.arange(mod.UInt32, i+2)
+        col = dr.arange(mod.UInt32, i+2) + 1
 
         res = frozen(x, row, col)
         ref = func(x, row, col)

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -3430,8 +3430,10 @@ def test90_tensor_slicing(t, auto_opaque):
     for i in range(3):
         shape = ((i + 5), 10)
         x = mod.TensorXf(dr.arange(mod.Float, dr.prod(shape)), shape=shape)
-        row = dr.arange(mod.UInt32, i + 4)
-        col = dr.arange(mod.UInt32, 3) + 1
+        # Both row and col must have the same length for advanced indexing
+        n = 3
+        row = dr.arange(mod.UInt32, n)
+        col = dr.arange(mod.UInt32, n) + 1
 
         res = frozen(x, row, col)
         ref = func(x, row, col)

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -3505,11 +3505,12 @@ def test90_tensor_slicing(t, auto_opaque):
 
     frozen = dr.freeze(func, auto_opaque=auto_opaque)
 
-    for i in range(3):
+    for i in range(4):
         shape = ((i + 5), 10)
         x = mod.TensorXf(dr.arange(mod.Float, dr.prod(shape)), shape=shape)
-        row = dr.arange(mod.UInt32, i + 4)
-        col = dr.arange(mod.UInt32, 3) + 1
+        # Both row and col must have the same length for advanced indexing
+        row = dr.arange(mod.UInt32, i+2)
+        col = dr.arange(mod.UInt32, i+2) + 1
 
         res = frozen(x, row, col)
         ref = func(x, row, col)
@@ -4001,7 +4002,6 @@ def test105_batched_gemm_varying_batch(t, auto_opaque):
         assert dr.allclose(res, ref, atol=1e-3)
 
 
-
 @pytest.test_arrays("float32, jit, shape=(*)")
 @pytest.mark.parametrize("auto_opaque", [False, True])
 def test106_nested_switch(t, auto_opaque):
@@ -4060,3 +4060,31 @@ def test107_frozen_getter(t, auto_opaque):
         assert dr.all(res == t([1 + it, 1 + it, 1 + it, 2 + it, 2 + it]))
 
     assert func.n_recordings == 1
+
+
+@pytest.test_arrays("float32, jit, diff, shape=(*)")
+@pytest.mark.parametrize("auto_opaque", [False, True])
+@pytest.mark.xfail(reason="Consecutive advanced + slice dims bakes "
+                           "advanced_size in the kernel")
+def test108_tensor_slicing_advanced_trailing(t, auto_opaque):
+    """
+    Tests advanced tensor indexing with a trailing slice dimension
+    inside frozen functions. The tensor shape is fixed so the freeze
+    key matches and replay is attempted with differently sized arrays.
+    """
+    mod = sys.modules[t.__module__]
+
+    def func(x: mod.TensorXf, row: mod.UInt32):
+        return x[row, :]
+
+    frozen = dr.freeze(func, auto_opaque=auto_opaque)
+
+    x = mod.TensorXf(dr.arange(mod.Float, 10 * 3), shape=(10, 3))
+    for i in range(4):
+        row = dr.arange(mod.UInt32, i + 2)
+
+        res = frozen(x, row)
+        ref = func(x, row)
+
+        assert dr.allclose(res, ref)
+

--- a/tests/test_pytorch_indexing.py
+++ b/tests/test_pytorch_indexing.py
@@ -1,0 +1,509 @@
+"""
+Test PyTorch-compatible tensor indexing behavior.
+
+This test suite ensures that Dr.Jit tensor indexing is strictly compatible
+with PyTorch, particularly for the critical requirement that integer indexing
+returns 0-D tensors (not Python scalars).
+"""
+
+import drjit as dr
+import pytest
+import sys
+
+# Optional PyTorch dependency
+try:
+    import torch
+    import numpy as np
+
+    HAS_TORCH = True
+except ImportError:
+    HAS_TORCH = False
+
+
+def skip_if_no_torch():
+    """Skip test if PyTorch is not available."""
+    if not HAS_TORCH:
+        pytest.skip("PyTorch not available")
+
+
+# Helper functions for conversion
+def drjit_to_torch(drjit_tensor):
+    """Convert Dr.Jit tensor to PyTorch tensor."""
+    if HAS_TORCH:
+        np_array = (
+            drjit_tensor.numpy()
+            if hasattr(drjit_tensor, "numpy")
+            else np.array(drjit_tensor)
+        )
+        return torch.from_numpy(np_array).float()
+    return None
+
+
+def assert_shape_equal(dr_tensor, pt_tensor, msg=""):
+    """Assert that Dr.Jit and PyTorch tensors have equal shapes."""
+    dr_shape = dr_tensor.shape
+    pt_shape = tuple(pt_tensor.shape)
+    assert (
+        dr_shape == pt_shape
+    ), f"{msg}\nDr.Jit shape: {dr_shape}, PyTorch shape: {pt_shape}"
+
+
+def assert_values_equal(dr_tensor, pt_tensor, rtol=1e-5, atol=1e-7, msg=""):
+    """Assert that Dr.Jit and PyTorch tensors have equal values."""
+    if HAS_TORCH:
+        dr_np = (
+            dr_tensor.numpy() if hasattr(dr_tensor, "numpy") else np.array(dr_tensor)
+        )
+        pt_np = pt_tensor.detach().cpu().numpy()
+        np.testing.assert_allclose(dr_np, pt_np, rtol=rtol, atol=atol, err_msg=msg)
+
+
+# =============================================================================
+# Basic Integer Indexing Tests
+# =============================================================================
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test01_single_int_index_1d_returns_0d(t):
+    """Test that single integer index on 1D tensor returns 0-D tensor."""
+    skip_if_no_torch()
+
+    # Create test data
+    data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    dr_tensor = t(data)
+    pt_tensor = torch.tensor(data, dtype=torch.float32)
+
+    # Test positive index
+    dr_result = dr_tensor[5]
+    pt_result = pt_tensor[5]
+
+    # CRITICAL: Should return 0-D tensor, not scalar
+    assert dr_result.ndim == 0, f"Expected ndim=0, got {dr_result.ndim}"
+    assert dr_result.shape == (), f"Expected shape=(), got {dr_result.shape}"
+    assert pt_result.ndim == 0, "PyTorch should also return 0-D tensor"
+
+    assert_shape_equal(dr_result, pt_result, "Single int index shape mismatch")
+    assert_values_equal(dr_result, pt_result, msg="Single int index value mismatch")
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test02_negative_int_index_1d_returns_0d(t):
+    """Test that negative integer index on 1D tensor returns 0-D tensor."""
+    skip_if_no_torch()
+
+    data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    dr_tensor = t(data)
+    pt_tensor = torch.tensor(data, dtype=torch.float32)
+
+    # Test negative indices
+    for idx in [-1, -5, -10]:
+        dr_result = dr_tensor[idx]
+        pt_result = pt_tensor[idx]
+
+        assert (
+            dr_result.ndim == 0
+        ), f"Index {idx}: Expected ndim=0, got {dr_result.ndim}"
+        assert (
+            dr_result.shape == ()
+        ), f"Index {idx}: Expected shape=(), got {dr_result.shape}"
+        assert_shape_equal(dr_result, pt_result, f"Negative index {idx} shape mismatch")
+        assert_values_equal(
+            dr_result, pt_result, msg=f"Negative index {idx} value mismatch"
+        )
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test03_multi_int_index_2d_returns_0d(t):
+    """Test that multiple integer indices on 2D tensor return 0-D tensor."""
+    skip_if_no_torch()
+
+    data = list(range(20))
+    dr_tensor = t(data, shape=(4, 5))
+    pt_tensor = torch.tensor(data, dtype=torch.float32).reshape(4, 5)
+
+    # Test various index combinations
+    test_cases = [(0, 0), (2, 3), (3, 4), (-1, -1), (-2, 3)]
+
+    for i, j in test_cases:
+        dr_result = dr_tensor[i, j]
+        pt_result = pt_tensor[i, j]
+
+        assert (
+            dr_result.ndim == 0
+        ), f"Index ({i}, {j}): Expected ndim=0, got {dr_result.ndim}"
+        assert (
+            dr_result.shape == ()
+        ), f"Index ({i}, {j}): Expected shape=(), got {dr_result.shape}"
+        assert_shape_equal(dr_result, pt_result, f"Index ({i}, {j}) shape mismatch")
+        assert_values_equal(
+            dr_result, pt_result, msg=f"Index ({i}, {j}) value mismatch"
+        )
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test04_single_int_index_2d_reduces_dim(t):
+    """Test that single integer index on 2D tensor reduces dimension."""
+    skip_if_no_torch()
+
+    data = list(range(20))
+    dr_tensor = t(data, shape=(4, 5))
+    pt_tensor = torch.tensor(data, dtype=torch.float32).reshape(4, 5)
+
+    # Single index should return 1D tensor
+    for idx in [0, 2, -1]:
+        dr_result = dr_tensor[idx]
+        pt_result = pt_tensor[idx]
+
+        assert (
+            dr_result.ndim == 1
+        ), f"Index {idx}: Expected ndim=1, got {dr_result.ndim}"
+        assert dr_result.shape == (
+            5,
+        ), f"Index {idx}: Expected shape=(5,), got {dr_result.shape}"
+        assert_shape_equal(dr_result, pt_result, f"Single index {idx} shape mismatch")
+        assert_values_equal(
+            dr_result, pt_result, msg=f"Single index {idx} value mismatch"
+        )
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test05_multi_int_index_3d_returns_0d(t):
+    """Test that full indexing on 3D tensor returns 0-D tensor."""
+    skip_if_no_torch()
+
+    data = list(range(60))
+    dr_tensor = t(data, shape=(3, 4, 5))
+    pt_tensor = torch.tensor(data, dtype=torch.float32).reshape(3, 4, 5)
+
+    test_cases = [(0, 0, 0), (1, 2, 3), (2, 3, 4), (-1, -1, -1)]
+
+    for i, j, k in test_cases:
+        dr_result = dr_tensor[i, j, k]
+        pt_result = pt_tensor[i, j, k]
+
+        assert (
+            dr_result.ndim == 0
+        ), f"Index ({i}, {j}, {k}): Expected ndim=0, got {dr_result.ndim}"
+        assert (
+            dr_result.shape == ()
+        ), f"Index ({i}, {j}, {k}): Expected shape=(), got {dr_result.shape}"
+        assert_shape_equal(
+            dr_result, pt_result, f"Index ({i}, {j}, {k}) shape mismatch"
+        )
+        assert_values_equal(
+            dr_result, pt_result, msg=f"Index ({i}, {j}, {k}) value mismatch"
+        )
+
+
+# =============================================================================
+# Slicing Tests
+# =============================================================================
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test06_slice_1d(t):
+    """Test basic slicing on 1D tensor."""
+    skip_if_no_torch()
+
+    data = list(range(10))
+    dr_tensor = t(data)
+    pt_tensor = torch.tensor(data, dtype=torch.float32)
+
+    test_slices = [
+        slice(2, 7),  # [2:7]
+        slice(None, 5),  # [:5]
+        slice(3, None),  # [3:]
+        slice(None, None, 2),  # [::2]
+        slice(8, 2, -1),  # [8:2:-1]
+        slice(None, None, -1),  # [::-1]
+    ]
+
+    for s in test_slices:
+        dr_result = dr_tensor[s]
+        pt_result = pt_tensor[s]
+
+        assert_shape_equal(dr_result, pt_result, f"Slice {s} shape mismatch")
+        assert_values_equal(dr_result, pt_result, msg=f"Slice {s} value mismatch")
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test07_slice_2d(t):
+    """Test slicing on 2D tensor."""
+    skip_if_no_torch()
+
+    data = list(range(20))
+    dr_tensor = t(data, shape=(4, 5))
+    pt_tensor = torch.tensor(data, dtype=torch.float32).reshape(4, 5)
+
+    test_cases = [
+        (slice(1, 3), slice(None)),  # [1:3, :]
+        (slice(None), slice(2, 4)),  # [:, 2:4]
+        (slice(1, 3), slice(2, 4)),  # [1:3, 2:4]
+        (slice(None, None, -1), slice(None)),  # [::-1, :]
+    ]
+
+    for idx in test_cases:
+        dr_result = dr_tensor[idx]
+        pt_result = pt_tensor[idx]
+
+        assert_shape_equal(dr_result, pt_result, f"Slice {idx} shape mismatch")
+        assert_values_equal(dr_result, pt_result, msg=f"Slice {idx} value mismatch")
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test08_mixed_int_slice(t):
+    """Test mixing integer and slice indices."""
+    skip_if_no_torch()
+
+    data = list(range(20))
+    dr_tensor = t(data, shape=(4, 5))
+    pt_tensor = torch.tensor(data, dtype=torch.float32).reshape(4, 5)
+
+    test_cases = [
+        (0, slice(None)),  # [0, :]
+        (slice(None), 0),  # [:, 0]
+        (2, slice(1, 4)),  # [2, 1:4]
+        (slice(1, 3), 2),  # [1:3, 2]
+    ]
+
+    for idx in test_cases:
+        dr_result = dr_tensor[idx]
+        pt_result = pt_tensor[idx]
+
+        assert_shape_equal(dr_result, pt_result, f"Mixed index {idx} shape mismatch")
+        assert_values_equal(
+            dr_result, pt_result, msg=f"Mixed index {idx} value mismatch"
+        )
+
+
+# =============================================================================
+# Ellipsis Tests
+# =============================================================================
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test09_ellipsis(t):
+    """Test ellipsis (...) indexing."""
+    skip_if_no_torch()
+
+    data = list(range(60))
+    dr_tensor = t(data, shape=(3, 4, 5))
+    pt_tensor = torch.tensor(data, dtype=torch.float32).reshape(3, 4, 5)
+
+    test_cases = [
+        (Ellipsis,),  # [...]
+        (Ellipsis, 0),  # [..., 0]
+        (0, Ellipsis),  # [0, ...]
+        (1, Ellipsis, 2),  # [1, ..., 2]
+    ]
+
+    for idx in test_cases:
+        dr_result = dr_tensor[idx]
+        pt_result = pt_tensor[idx]
+
+        assert_shape_equal(dr_result, pt_result, f"Ellipsis {idx} shape mismatch")
+        assert_values_equal(dr_result, pt_result, msg=f"Ellipsis {idx} value mismatch")
+
+
+# =============================================================================
+# None/newaxis Tests
+# =============================================================================
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test10_newaxis(t):
+    """Test None/newaxis indexing."""
+    skip_if_no_torch()
+
+    data = list(range(10))
+    dr_tensor = t(data)
+    pt_tensor = torch.tensor(data, dtype=torch.float32)
+
+    test_cases = [
+        (None, slice(None)),  # [None, :]
+        (slice(None), None),  # [:, None]
+        (None, slice(None), None),  # [None, :, None]
+    ]
+
+    for idx in test_cases:
+        dr_result = dr_tensor[idx]
+        pt_result = pt_tensor[idx]
+
+        assert_shape_equal(dr_result, pt_result, f"Newaxis {idx} shape mismatch")
+        assert_values_equal(dr_result, pt_result, msg=f"Newaxis {idx} value mismatch")
+
+
+# =============================================================================
+# Edge Cases
+# =============================================================================
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test11_empty_slice(t):
+    """Test slicing that produces empty tensor."""
+    skip_if_no_torch()
+
+    data = list(range(10))
+    dr_tensor = t(data)
+    pt_tensor = torch.tensor(data, dtype=torch.float32)
+
+    dr_result = dr_tensor[5:5]
+    pt_result = pt_tensor[5:5]
+
+    assert_shape_equal(dr_result, pt_result, "Empty slice shape mismatch")
+    assert dr_result.shape == (0,), f"Expected shape=(0,), got {dr_result.shape}"
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test12_single_element_tensor(t):
+    """Test indexing single element tensor."""
+    skip_if_no_torch()
+
+    dr_tensor = t([42.0])
+    pt_tensor = torch.tensor([42.0], dtype=torch.float32)
+
+    dr_result = dr_tensor[0]
+    pt_result = pt_tensor[0]
+
+    assert dr_result.ndim == 0, f"Expected ndim=0, got {dr_result.ndim}"
+    assert dr_result.shape == (), f"Expected shape=(), got {dr_result.shape}"
+    assert_shape_equal(dr_result, pt_result, "Single element shape mismatch")
+    assert_values_equal(dr_result, pt_result, msg="Single element value mismatch")
+
+
+# =============================================================================
+# Array Indexing Tests (using Dr.Jit integer arrays)
+# =============================================================================
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test13_array_index_1d(t):
+    """Test array indexing on 1D tensor."""
+    skip_if_no_torch()
+
+    data = list(range(10))
+    dr_tensor = t(data)
+    pt_tensor = torch.tensor(data, dtype=torch.float32)
+
+    # Create index array
+    indices = [0, 2, 4, 6, 8]
+    index_type = dr.uint32_array_t(dr.array_t(t))
+    dr_indices = index_type(indices)
+    pt_indices = torch.tensor(indices, dtype=torch.long)
+
+    dr_result = dr_tensor[dr_indices]
+    pt_result = pt_tensor[pt_indices]
+
+    assert_shape_equal(dr_result, pt_result, "Array index shape mismatch")
+    assert_values_equal(dr_result, pt_result, msg="Array index value mismatch")
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test14_array_index_2d(t):
+    """Test array indexing on 2D tensor (first dimension)."""
+    skip_if_no_torch()
+
+    data = list(range(20))
+    dr_tensor = t(data, shape=(4, 5))
+    pt_tensor = torch.tensor(data, dtype=torch.float32).reshape(4, 5)
+
+    # Create index array
+    indices = [0, 2, 3]
+    index_type = dr.uint32_array_t(dr.array_t(t))
+    dr_indices = index_type(indices)
+    pt_indices = torch.tensor(indices, dtype=torch.long)
+
+    dr_result = dr_tensor[dr_indices]
+    pt_result = pt_tensor[pt_indices]
+
+    assert_shape_equal(dr_result, pt_result, "Array index 2D shape mismatch")
+    assert dr_result.shape == (3, 5), f"Expected shape=(3, 5), got {dr_result.shape}"
+    assert_values_equal(dr_result, pt_result, msg="Array index 2D value mismatch")
+
+
+# =============================================================================
+# Assignment Tests
+# =============================================================================
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test15_setitem_single_element(t):
+    """Test assigning to single element."""
+    skip_if_no_torch()
+
+    data = list(range(10))
+    dr_tensor = t(data)
+    pt_tensor = torch.tensor(data, dtype=torch.float32)
+
+    dr_tensor[5] = 100.0
+    pt_tensor[5] = 100.0
+
+    assert_values_equal(dr_tensor, pt_tensor, msg="Single element assignment mismatch")
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test16_setitem_slice(t):
+    """Test assigning to slice."""
+    skip_if_no_torch()
+
+    data = list(range(10))
+    dr_tensor = t(data)
+    pt_tensor = torch.tensor(data, dtype=torch.float32)
+
+    dr_tensor[2:7] = 100.0
+    pt_tensor[2:7] = 100.0
+
+    assert_values_equal(dr_tensor, pt_tensor, msg="Slice assignment mismatch")
+
+
+# =============================================================================
+# Comprehensive Compatibility Test
+# =============================================================================
+
+
+@pytest.test_arrays("is_tensor, float32, is_jit")
+def test17_comprehensive_indexing_compatibility(t):
+    """Comprehensive test covering multiple indexing scenarios."""
+    skip_if_no_torch()
+
+    # Test with different tensor shapes
+    test_configs = [
+        (10,),  # 1D
+        (4, 5),  # 2D
+        (2, 3, 4),  # 3D
+    ]
+
+    for shape in test_configs:
+        size = 1
+        for dim in shape:
+            size *= dim
+
+        data = list(range(size))
+        dr_tensor = t(data, shape=shape) if len(shape) > 1 else t(data)
+        pt_tensor = torch.tensor(data, dtype=torch.float32).reshape(shape)
+
+        # Test 1: Verify shapes match
+        assert_shape_equal(dr_tensor, pt_tensor, f"Initial shape mismatch for {shape}")
+
+        # Test 2: Full slice should preserve shape
+        dr_result = dr_tensor[...]
+        pt_result = pt_tensor[...]
+        assert_shape_equal(dr_result, pt_result, f"Ellipsis shape mismatch for {shape}")
+
+        # Test 3: Integer index on first dimension
+        dr_result = dr_tensor[0]
+        pt_result = pt_tensor[0]
+        assert_shape_equal(
+            dr_result, pt_result, f"First dim index shape mismatch for {shape}"
+        )
+
+        # Test 4: If multidimensional, test full integer indexing
+        if len(shape) > 1:
+            full_idx = tuple([0] * len(shape))
+            dr_result = dr_tensor[full_idx]
+            pt_result = pt_tensor[full_idx]
+            assert dr_result.ndim == 0, f"Full index should return 0-D for {shape}"
+            assert_shape_equal(
+                dr_result, pt_result, f"Full index shape mismatch for {shape}"
+            )
+

--- a/tests/test_pytorch_indexing.py
+++ b/tests/test_pytorch_indexing.py
@@ -214,6 +214,10 @@ def test06_slice_1d(t):
         slice(None, 5),  # [:5]
         slice(3, None),  # [3:]
         slice(None, None, 2),  # [::2]
+    ]
+
+    # PyTorch doesn't support negative step slices, so test Dr.Jit independently
+    drjit_only_slices = [
         slice(8, 2, -1),  # [8:2:-1]
         slice(None, None, -1),  # [::-1]
     ]
@@ -224,6 +228,12 @@ def test06_slice_1d(t):
 
         assert_shape_equal(dr_result, pt_result, f"Slice {s} shape mismatch")
         assert_values_equal(dr_result, pt_result, msg=f"Slice {s} value mismatch")
+
+    # Test Dr.Jit-only slices (negative steps)
+    for s in drjit_only_slices:
+        dr_result = dr_tensor[s]
+        # Just verify it doesn't crash and returns reasonable shape
+        assert dr_result.ndim == 1, f"Slice {s} should preserve 1D"
 
 
 @pytest.test_arrays("is_tensor, float32, is_jit")
@@ -239,6 +249,10 @@ def test07_slice_2d(t):
         (slice(1, 3), slice(None)),  # [1:3, :]
         (slice(None), slice(2, 4)),  # [:, 2:4]
         (slice(1, 3), slice(2, 4)),  # [1:3, 2:4]
+    ]
+
+    # PyTorch doesn't support negative steps
+    drjit_only_cases = [
         (slice(None, None, -1), slice(None)),  # [::-1, :]
     ]
 
@@ -248,6 +262,12 @@ def test07_slice_2d(t):
 
         assert_shape_equal(dr_result, pt_result, f"Slice {idx} shape mismatch")
         assert_values_equal(dr_result, pt_result, msg=f"Slice {idx} value mismatch")
+
+    # Test Dr.Jit-only cases (negative steps)
+    for idx in drjit_only_cases:
+        dr_result = dr_tensor[idx]
+        # Just verify it doesn't crash and returns reasonable shape
+        assert dr_result.ndim == 2, f"Slice {idx} should preserve 2D"
 
 
 @pytest.test_arrays("is_tensor, float32, is_jit")

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -63,7 +63,7 @@ def test01_slice_index(t):
     check(shape=(3, 7), indices=(t(0), slice(0, 7, 3)),
           shape_out=(1, 3), index_out=t(0, 3, 6))
     check(shape=(3, 7), indices=(t(0), t(0, 3, 6)),
-          shape_out=(1, 3), index_out=t(0, 3, 6))
+          shape_out=(3,), index_out=t(0, 3, 6))  # Consecutive advanced indices → single dimension
     check(shape=(3, 7), indices=(2, slice(None, None, None)),
           shape_out=(7,), index_out=t(14, 15, 16, 17, 18, 19, 20))
     check(shape=(3, 7), indices=(slice(None, None, None), 2),
@@ -758,7 +758,7 @@ def test24_multidim_scalar(t):
 
 
 @pytest.test_arrays("float32, jit")
-def test25_multidim_complex(t):
+def test25_multidim_advanced(t):
     pytest.importorskip("torch")
 
     mod = sys.modules[t.__module__]
@@ -777,5 +777,29 @@ def test25_multidim_complex(t):
     index_torch = index.torch().long()
     ref = x_torch[index_torch, :, index_torch]
     res = x[index, :, index]
+
+    assert dr.allclose(res, ref)
+
+
+@pytest.test_arrays("float32, jit")
+def test26_4d_advanced(t):
+    pytest.importorskip("torch")
+
+    mod = sys.modules[t.__module__]
+    UInt32 = mod.UInt32
+    TensorXf = mod.TensorXf
+    Float = mod.Float
+
+    shape = (10, 10, 10, 10)
+    rng = dr.rng()
+    index = dr.arange(UInt32, 5) + 1
+
+    x = rng.random(Float, dr.prod(shape))
+    x = TensorXf(x, shape)
+    x_torch = x.torch()
+
+    index_torch = index.torch().long()
+    ref = x_torch[index_torch, :, index_torch, :]
+    res = x[index, :, index, :]
 
     assert dr.allclose(res, ref)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -686,3 +686,96 @@ def test23_item_array(t):
 
     with pytest.raises(RuntimeError, match='can only convert arrays of length 1'):
         t([]).item()
+
+
+@pytest.test_arrays('is_tensor, -bool')
+def test24_pytorch_compat_scalar_indexing(t):
+    """
+    Test PyTorch-compatible indexing behavior: integer indexing should
+    return 0-D tensors, not Python scalars.
+
+    This is critical for PyTorch compatibility, as PyTorch always returns
+    tensors (even 0-D) from indexing operations, unlike NumPy which returns
+    Python scalars.
+    """
+    # Test 1: Single integer index on 1D tensor returns 0-D tensor
+    v = t([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    result = v[5]
+    assert result.ndim == 0, f"Single int index should return 0-D tensor, got ndim={result.ndim}"
+    assert result.shape == (), f"Single int index should return shape=(), got {result.shape}"
+
+    # Test 2: Negative index also returns 0-D tensor
+    result = v[-1]
+    assert result.ndim == 0, f"Negative int index should return 0-D tensor, got ndim={result.ndim}"
+    assert result.shape == (), f"Negative int index should return shape=(), got {result.shape}"
+
+    # Test 3: Multiple integer indices on 2D tensor return 0-D tensor
+    v2 = t(list(range(20)), shape=(4, 5))
+    result = v2[2, 3]
+    assert result.ndim == 0, f"Multi-int index should return 0-D tensor, got ndim={result.ndim}"
+    assert result.shape == (), f"Multi-int index should return shape=(), got {result.shape}"
+
+    # Test 4: Single index on 2D tensor reduces dimension (returns 1D)
+    result = v2[2]
+    assert result.ndim == 1, f"Single index on 2D should return 1-D tensor, got ndim={result.ndim}"
+    assert result.shape == (5,), f"Single index on 2D should return shape=(5,), got {result.shape}"
+
+    # Test 5: Full indexing on 3D tensor returns 0-D tensor
+    v3 = t(list(range(60)), shape=(3, 4, 5))
+    result = v3[1, 2, 3]
+    assert result.ndim == 0, f"Full 3D index should return 0-D tensor, got ndim={result.ndim}"
+    assert result.shape == (), f"Full 3D index should return shape=(), got {result.shape}"
+
+    # Test 6: Verify the 0-D tensor contains the correct value
+    # For consistency check, compare with item() method
+    v_simple = t([42])
+    result_0d = v_simple[0]
+    assert result_0d.ndim == 0
+    # The 0-D tensor should have the same value as item()
+    assert result_0d.item() == 42
+
+
+@pytest.test_arrays("float32, jit")
+def test24_multidim_scalar(t):
+    pytest.importorskip("torch")
+
+    mod = sys.modules[t.__module__]
+    UInt32 = mod.UInt32
+    TensorXf = mod.TensorXf
+    Float = mod.Float
+
+    shape = (10, 10, 10)
+    rng = dr.rng()
+
+    x = rng.random(Float, dr.prod(shape))
+    x = TensorXf(x, shape)
+    x_torch = x.torch()
+
+    ref = x_torch[:, 1, :]
+    res = x[:, 1, :]
+
+    assert dr.allclose(res, ref)
+
+
+@pytest.test_arrays("float32, jit")
+def test25_multidim_complex(t):
+    pytest.importorskip("torch")
+
+    mod = sys.modules[t.__module__]
+    UInt32 = mod.UInt32
+    TensorXf = mod.TensorXf
+    Float = mod.Float
+
+    shape = (10, 10, 10)
+    rng = dr.rng()
+    index = dr.arange(UInt32, 5) + 1
+
+    x = rng.random(Float, dr.prod(shape))
+    x = TensorXf(x, shape)
+    x_torch = x.torch()
+
+    index_torch = index.torch().long()
+    ref = x_torch[index_torch, :, index_torch]
+    res = x[index, :, index]
+
+    assert dr.allclose(res, ref)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -63,7 +63,7 @@ def test01_slice_index(t):
     check(shape=(3, 7), indices=(t(0), slice(0, 7, 3)),
           shape_out=(1, 3), index_out=t(0, 3, 6))
     check(shape=(3, 7), indices=(t(0), t(0, 3, 6)),
-          shape_out=(1, 3), index_out=t(0, 3, 6))
+          shape_out=(3,), index_out=t(0, 3, 6))
     check(shape=(3, 7), indices=(2, slice(None, None, None)),
           shape_out=(7,), index_out=t(14, 15, 16, 17, 18, 19, 20))
     check(shape=(3, 7), indices=(slice(None, None, None), 2),
@@ -1127,3 +1127,219 @@ def test37_split(t):
         dr.split(dr.array_t(t)(1, 2, 3), 3)
     with pytest.raises(TypeError, match="expected a tensor"):
         dr.array_split(dr.array_t(t)(1, 2, 3), 3)
+
+
+@pytest.test_arrays("float32, jit")
+def test38_multidim_scalar(t):
+    pytest.importorskip("torch")
+
+    mod = sys.modules[t.__module__]
+    TensorXf = mod.TensorXf
+    Float = mod.Float
+
+    shape = (10, 10, 10)
+    rng = dr.rng()
+
+    x = rng.random(Float, dr.prod(shape))
+    x = TensorXf(x, shape)
+    x_torch = x.torch()
+
+    ref = x_torch[:, 1, :]
+    res = x[:, 1, :]
+
+    assert dr.allclose(res, ref)
+
+
+@pytest.test_arrays("float32, jit")
+def test39_multidim_advanced(t):
+    pytest.importorskip("torch")
+
+    mod = sys.modules[t.__module__]
+    UInt32 = mod.UInt32
+    TensorXf = mod.TensorXf
+    Float = mod.Float
+
+    shape = (10, 10, 10)
+    rng = dr.rng()
+    index = dr.arange(UInt32, 5) + 1
+
+    x = rng.random(Float, dr.prod(shape))
+    x = TensorXf(x, shape)
+    x_torch = x.torch()
+
+    index_torch = index.torch().long()
+    ref = x_torch[index_torch, :, index_torch]
+    res = x[index, :, index]
+
+    assert dr.allclose(res, ref)
+
+
+@pytest.test_arrays("float32, jit")
+def test40_advanced_indexing_broadcast(t):
+    """Size-1 array broadcast against a larger array in non-consecutive
+    advanced indexing."""
+    pytest.importorskip("torch")
+
+    mod = sys.modules[t.__module__]
+    UInt32 = mod.UInt32
+    TensorXf = mod.TensorXf
+    Float = mod.Float
+
+    shape = (4, 5, 6)
+    rng = dr.rng()
+
+    x = rng.random(Float, dr.prod(shape))
+    x = TensorXf(x, shape)
+    x_torch = x.torch()
+
+    idx_one = UInt32(2)
+    idx_many = dr.arange(UInt32, 3) + 1
+
+    ref = x_torch[idx_one.torch().long(), :, idx_many.torch().long()]
+    res = x[idx_one, :, idx_many]
+
+    assert dr.allclose(res, ref)
+
+
+@pytest.test_arrays("float32, jit")
+def test41_advanced_indexing_with_integer(t):
+    """Integer index between two array indices: the integer folds into the
+    base offset while the arrays share the broadcasted advanced index."""
+    pytest.importorskip("torch")
+
+    mod = sys.modules[t.__module__]
+    UInt32 = mod.UInt32
+    TensorXf = mod.TensorXf
+    Float = mod.Float
+
+    shape = (5, 6, 7)
+    rng = dr.rng()
+    index = dr.arange(UInt32, 4)
+
+    x = rng.random(Float, dr.prod(shape))
+    x = TensorXf(x, shape)
+    x_torch = x.torch()
+
+    index_torch = index.torch().long()
+    ref = x_torch[index_torch, 3, index_torch]
+    res = x[index, 3, index]
+
+    assert dr.allclose(res, ref)
+
+
+@pytest.test_arrays("float32, jit")
+def test42_advanced_indexing_coalesce(t):
+    """Multiple passthrough dims between array indices — the passthroughs
+    get coalesced into one synthetic component, but advanced indexing
+    must still produce correct results."""
+    pytest.importorskip("torch")
+
+    mod = sys.modules[t.__module__]
+    UInt32 = mod.UInt32
+    TensorXf = mod.TensorXf
+    Float = mod.Float
+
+    shape = (3, 4, 5, 6)
+    rng = dr.rng()
+    index = dr.arange(UInt32, 2)
+
+    x = rng.random(Float, dr.prod(shape))
+    x = TensorXf(x, shape)
+    x_torch = x.torch()
+
+    index_torch = index.torch().long()
+    ref = x_torch[index_torch, :, :, index_torch]
+    res = x[index, :, :, index]
+
+    assert dr.allclose(res, ref)
+
+
+@pytest.test_arrays("float32, jit")
+def test43_advanced_consecutive_integer(t):
+    """Integer between array indices does not break consecutiveness."""
+    pytest.importorskip("torch")
+
+    mod = sys.modules[t.__module__]
+    UInt32 = mod.UInt32
+    TensorXf = mod.TensorXf
+    Float = mod.Float
+
+    x = TensorXf(dr.arange(Float, 5 * 6 * 7 * 8), (5, 6, 7, 8))
+    x_torch = x.torch()
+
+    idx = dr.arange(UInt32, 4)
+    idx_torch = idx.torch().long()
+
+    ref = x_torch[:, idx_torch, 3, idx_torch]
+    res = x[:, idx, 3, idx]
+    assert dr.allclose(res, ref)
+
+
+@pytest.test_arrays("float32, jit")
+def test44_advanced_non_consecutive_none(t):
+    """None between array indices breaks consecutiveness."""
+    pytest.importorskip("torch")
+
+    mod = sys.modules[t.__module__]
+    UInt32 = mod.UInt32
+    TensorXf = mod.TensorXf
+    Float = mod.Float
+
+    y = TensorXf(dr.arange(Float, 5 * 6 * 7), (5, 6, 7))
+    y_torch = y.torch()
+
+    idx = dr.arange(UInt32, 4)
+    idx_torch = idx.torch().long()
+
+    ref = y_torch[:, idx_torch, None, idx_torch]
+    res = y[:, idx, None, idx]
+    assert dr.allclose(res, ref)
+
+
+@pytest.test_arrays("float32, jit")
+def test45_torch_array_indexing(t):
+    """Array (gather) indexing via __getitem__ must match PyTorch."""
+    pytest.importorskip("torch")
+
+    mod = sys.modules[t.__module__]
+    UInt32 = mod.UInt32
+    TensorXf = mod.TensorXf
+    Float = mod.Float
+
+    # 1D
+    x = TensorXf(dr.arange(Float, 10))
+    x_torch = x.torch()
+    idx = UInt32(0, 2, 4, 6, 8)
+    assert dr.allclose(x[idx], x_torch[idx.torch().long()])
+
+    # 2D (first dimension)
+    x = TensorXf(dr.arange(Float, 20), shape=(4, 5))
+    x_torch = x.torch()
+    idx = UInt32(0, 2, 3)
+    res = x[idx]
+    assert res.shape == (3, 5)
+    assert dr.allclose(res, x_torch[idx.torch().long()])
+
+
+@pytest.test_arrays("float32, jit")
+def test46_torch_setitem(t):
+    """Scalar and slice assignment on tensors must match PyTorch."""
+    pytest.importorskip("torch")
+
+    mod = sys.modules[t.__module__]
+    TensorXf = mod.TensorXf
+    Float = mod.Float
+
+    # Single element
+    x = TensorXf(dr.arange(Float, 10))
+    x_torch = x.torch().clone()
+    x[5] = 100.0
+    x_torch[5] = 100.0
+    assert dr.allclose(x, x_torch)
+
+    # Slice
+    x = TensorXf(dr.arange(Float, 10))
+    x_torch = x.torch().clone()
+    x[2:7] = 100.0
+    x_torch[2:7] = 100.0
+    assert dr.allclose(x, x_torch)


### PR DESCRIPTION
This PR makes advanced tensor indexing compatible with PyTorch and NumPy.

When indexing a tensor with an index array, we previously indexed all combinations of the arrays. In the following example, we are indexing the element at `[0, 0]`, `[0, 2]`, `[2, 0]`, `[2, 2]`.
```python
In [1]: import drjit as dr
In [2]: from drjit.auto import TensorXf, Float, UInt32
In [3]: x = TensorXf(dr.arange(Float, 16), (4, 4))
In [4]: x
Out[4]: 
[[0, 1, 2, 3],
 [4, 5, 6, 7],
 [8, 9, 10, 11],
 [12, 13, 14, 15]]
In [5]: x[UInt32(0, 2), UInt32(0, 2)]
Out[5]: 
[[0, 2],
 [8, 10]]
```

In contrast, PyTorch and NumPy handle this case differently. If arrays are used to index into tensors, these frameworks only return the entries at the diagonal coordinates `[0, 0]` and `[2, 2]`. This PR changes the behavior of the indexing function to match that of PyTorch.

```python
In [1]: import drjit as dr
In [2]: from drjit.auto import TensorXf, Float, UInt32
In [3]: x = TensorXf(dr.arange(Float, 16), (4, 4))
In [4]: x
Out[4]: 
[[0, 1, 2, 3],
 [4, 5, 6, 7],
 [8, 9, 10, 11],
 [12, 13, 14, 15]]
In [5]: x[UInt32(0, 2), UInt32(0, 2)]
Out[5]: [0, 10]
```

The PR also adds tests that ensure compatibility with the PyTorch indexing mechanism.