### PR TITLE
improve doc and error message when binary fails to load

### DIFF
--- a/docs/what.rst
+++ b/docs/what.rst
@@ -44,6 +44,10 @@ To install the latest version of Dr.Jit for Python, run the following shell comm
 
    $ python -m pip install --upgrade drjit
 
+The binary extension requires ``libatomic`` to be installed on the system. It is
+part of most distributions, but not all. If needed, install it using your 
+distribution's package manager.
+
 With that taken care of, let's see how Dr.Jit works in the context of a simple
 example.
 

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -9,11 +9,12 @@ with detail.scoped_rtld_deepbind():
         import platform
         py_ver_pkg = detail._PYTHON_VERSION
         py_ver_cur = platform.python_version()
+        filename = _drjit_ext.__file__
 
         err = ImportError(
-            f'Could not import the Dr.Jit binary extension. It is likely that '
-            f'the Python version for which Dr.Jit was compiled ({py_ver_pkg}) '
-            f'is incompatible with the current interpreter ({py_ver_cur}).')
+            f'Could not import the Dr.Jit binary extension at {filename}. '
+            f'It is likely that the Python version for which Dr.Jit was compiled ({py_ver_pkg}) '
+            f'is incompatible with the current interpreter ({py_ver_cur}), or that a binary dependency is missing.')
 
         err.__cause__ = e
         raise err


### PR DESCRIPTION
Improve the error message when the binary extension fails to load, provide the file path and a hint to check binary dependencies.

Added a line about the need of libatomic in the `what` documentation, so users are aware of it.

fixes #484 