### PR TITLE
Add `drjit.assert_allclose()` for correctness checks in testcases

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -154,6 +154,7 @@ Also relevant here are :py:func:`any`, :py:func:`all`, :py:func:`none`, and :py:
 .. autofunction:: isnan
 .. autofunction:: isfinite
 .. autofunction:: allclose
+.. autofunction:: assert_allclose
 
 Miscellaneous operations
 ------------------------

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -225,6 +225,133 @@ def allclose(
                 return False
         return True
 
+
+def assert_allclose(
+    actual: object,
+    desired: object,
+    rtol: Optional[float] = None,
+    atol: Optional[float] = None,
+    equal_nan: bool = False,
+    err_msg: str = '',
+) -> None:
+    r'''
+    Raise an ``AssertionError`` if two arrays are not element-wise equal within
+    a given error tolerance.
+
+    This is the assertion-raising counterpart of :py:func:`drjit.allclose` and
+    is analogous to ``numpy.testing.assert_allclose``. Elements are considered
+    equal if
+
+    .. math::
+        |\texttt{actual} - \texttt{desired}| \le
+        |\texttt{desired}| \cdot \texttt{rtol} + \texttt{atol}.
+
+    See :py:func:`drjit.allclose` for the default values of ``rtol`` and
+    ``atol`` (they depend on the input precision).
+
+    Unlike ``numpy.testing.assert_allclose``, the happy path stays on device:
+    the only host-visible reduction is a single boolean, and mismatch count /
+    worst-case absolute and relative differences are only read back when the
+    comparison fails.
+
+    Args:
+        actual (object): A Dr.Jit array or other kind of numeric sequence type.
+
+        desired (object): A Dr.Jit array or other kind of numeric sequence type.
+          Its magnitude sets the relative-tolerance scale.
+
+        rtol (float): Relative error threshold. Defaults depend on precision
+          (see :py:func:`drjit.allclose`).
+
+        atol (float): Absolute error threshold. Defaults depend on precision.
+
+        equal_nan (bool): If **actual** and **desired** *both* contain a *NaN*
+          entry at the same position, should they compare equal?
+
+        err_msg (str): Optional prefix prepended to the generated error message.
+
+    Raises:
+        AssertionError: If the arrays are not equal within the given tolerance.
+    '''
+
+    if is_array_v(actual) or is_array_v(desired):
+        a, b = detach(actual), detach(desired)
+
+        if is_special_v(a):
+            a = array_t(a)(a)
+        if is_special_v(b):
+            b = array_t(b)(b)
+
+        if is_array_v(a):
+            diff = a - b
+        else:
+            diff = b - a
+
+        a = type(diff)(a)
+        b = type(diff)(b)
+
+        vt = type_v(diff)
+
+        if vt == VarType.Float16:
+            rtol_ref, atol_ref = 1e-2, 1e-2
+        elif vt == VarType.Float32:
+            rtol_ref, atol_ref = 1e-3, 1e-5
+        else:
+            rtol_ref, atol_ref = 1e-5, 1e-8
+
+        atol_c = atol_ref if atol is None else atol
+        rtol_c = rtol_ref if rtol is None else rtol
+
+        abs_diff = abs(diff)
+        cond = abs_diff <= abs(b) * rtol_c + atol_c
+
+        # plus/minus infinity
+        if is_float_v(a):
+            cond |= a == b
+
+        if equal_nan:
+            cond |= isnan(a) & isnan(b)
+
+        if all(cond, axis=None):
+            return
+
+        # Mismatching elements only contribute to the diagnostic reductions.
+        mismatched = ~cond
+        sel_abs = select(mismatched, abs_diff, 0)
+        denom = abs(b) + atol_c
+        denom_safe = select(denom > 0, denom, 1)
+        sel_rel = select(mismatched, abs_diff / denom_safe, 0)
+
+        n_mismatch = int(count(mismatched, axis=None).array[0])
+        n_total = width(cond)
+        max_abs = float(max(sel_abs, axis=None).array[0])
+        max_rel = float(max(sel_rel, axis=None).array[0])
+
+        def _labeled(name, arr):
+            label = f' {name}: '
+            return label + repr(arr).replace('\n', '\n' + ' ' * len(label))
+
+        prefix = err_msg + '\n' if err_msg else ''
+        raise AssertionError(
+            f"{prefix}"
+            f"Arrays are not equal to tolerance rtol={rtol_c:g}, atol={atol_c:g}\n"
+            f"Mismatched elements: {n_mismatch} / {n_total} "
+            f"({100.0 * n_mismatch / n_total:.3g}%)\n"
+            f"Max absolute difference: {max_abs:.6g}\n"
+            f"Max relative difference: {max_rel:.6g}\n"
+            f"{_labeled('ACTUAL', a)}\n"
+            f"{_labeled('DESIRED', b)}"
+        )
+
+    if not allclose(actual, desired, rtol, atol, equal_nan):
+        prefix = err_msg + '\n' if err_msg else ''
+        raise AssertionError(
+            f"{prefix}"
+            f"assert_allclose() failed: "
+            f"actual={actual!r}, desired={desired!r}"
+        )
+
+
 # -------------------------------------------------------------------
 #   "Safe" functions that avoid domain errors due to rounding
 # -------------------------------------------------------------------

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -50,6 +50,91 @@ def test02_allclose():
     assert dr.allclose(np.array([1, 2, 3]), dr.scalar.Array3f(1, 2, 3))
     assert dr.allclose(np.array([1, float('nan'), 3.0]), [1, float('nan'), 3], equal_nan=True)
 
+
+def test02b_assert_allclose():
+    # Scalar / Python sequence path
+    dr.assert_allclose(2, 2)
+    dr.assert_allclose([1, 2, 3], [1, 2, 3])
+    dr.assert_allclose([1, 1, 1], 1)
+    with pytest.raises(AssertionError):
+        dr.assert_allclose(2, 3)
+    with pytest.raises(AssertionError):
+        dr.assert_allclose([1, 2, 3], [1, 4, 3])
+
+    # NaN
+    with pytest.raises(AssertionError):
+        dr.assert_allclose(float('nan'), float('nan'))
+    dr.assert_allclose(float('nan'), float('nan'), equal_nan=True)
+
+    # err_msg is prepended on failure
+    with pytest.raises(AssertionError, match='my prefix'):
+        dr.assert_allclose([1, 2, 3], [1, 4, 3], err_msg='my prefix')
+
+
+@pytest.test_arrays('float32,shape=(*),jit,is_diff')
+def test02c_assert_allclose_array(t):
+    dr.assert_allclose(t(1, 2, 3), t(1, 2, 3))
+    dr.assert_allclose(t(1, 2, 3), t(1.0001, 2.0, 3.0), rtol=1e-3, atol=1e-3)
+
+    # Exact failure message (rtol=atol=0 keeps formatting stable).
+    expected = (
+        "Arrays are not equal to tolerance rtol=0, atol=0\n"
+        "Mismatched elements: 1 / 3 (33.3%)\n"
+        "Max absolute difference: 3\n"
+        "Max relative difference: 0.6\n"
+        " ACTUAL: [1, 2, 3]\n"
+        " DESIRED: [1, 5, 3]"
+    )
+    with pytest.raises(AssertionError) as ei:
+        dr.assert_allclose(t(1, 2, 3), t(1, 5, 3), rtol=0, atol=0)
+    assert str(ei.value) == expected
+
+    # err_msg is prepended verbatim, one line above the diagnostic block.
+    with pytest.raises(AssertionError) as ei:
+        dr.assert_allclose(t(1, 2, 3), t(1, 5, 3), rtol=0, atol=0,
+                           err_msg='boom')
+    assert str(ei.value) == 'boom\n' + expected
+
+    # Infinity: equal via the a == b branch.
+    inf = float('inf')
+    dr.assert_allclose(t(1, inf, 3), t(1, inf, 3))
+    with pytest.raises(AssertionError) as ei:
+        dr.assert_allclose(t(1, inf, 3), t(1, 2, 3))
+    assert str(ei.value) == (
+        "Arrays are not equal to tolerance rtol=0.001, atol=1e-05\n"
+        "Mismatched elements: 1 / 3 (33.3%)\n"
+        "Max absolute difference: inf\n"
+        "Max relative difference: inf\n"
+        " ACTUAL: [1, inf, 3]\n"
+        " DESIRED: [1, 2, 3]"
+    )
+
+    # NaN handling
+    nan = float('nan')
+    with pytest.raises(AssertionError):
+        dr.assert_allclose(t(1, nan, 3), t(1, nan, 3))
+    dr.assert_allclose(t(1, nan, 3), t(1, nan, 3), equal_nan=True)
+
+
+@pytest.test_arrays('float32,is_tensor,jit,is_diff')
+def test02d_assert_allclose_tensor(t):
+    a = t([1, 2, 3, 4], (2, 2))
+    dr.assert_allclose(a, t([1, 2, 3, 4], (2, 2)))
+
+    with pytest.raises(AssertionError) as ei:
+        dr.assert_allclose(a, t([1, 2, 3, 9], (2, 2)), rtol=0, atol=0)
+    assert str(ei.value) == (
+        "Arrays are not equal to tolerance rtol=0, atol=0\n"
+        "Mismatched elements: 1 / 4 (25%)\n"
+        "Max absolute difference: 5\n"
+        "Max relative difference: 0.555556\n"
+        " ACTUAL: [[1, 2],\n"
+        "          [3, 4]]\n"
+        " DESIRED: [[1, 2],\n"
+        "           [3, 9]]"
+    )
+
+
 @pytest.test_arrays('-bool,shape=(3)', '-bool,shape=(3, *)', '-bool,shape=(*, *)')
 def test03_binop_simple(t):
     a = t(1, 2, 3)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -134,6 +134,27 @@ def test07_evaluated_format_big_2d(t):
         '[[0, 0],\n [1, 0],\n [2, 0],\n .. 94 skipped ..,\n [97, 0],\n [98, 0],\n [99, 0]]'
 
 
+@pytest.test_arrays('is_tensor, uint32, jit')
+def test07b_evaluated_format_tensor(t):
+    # Small tensor: no summarization
+    assert dr.format("{}", dr.reshape(dr.arange(t, 6), (2, 3))) == \
+        "[[0, 1, 2],\n [3, 4, 5]]"
+
+    # Large 1D tensor: first-3 / last-3 summarization
+    assert dr.format("{}", dr.arange(t, 100)) == \
+        "[0, 1, 2, .. 94 skipped .., 97, 98, 99]"
+
+    # Large 2D tensor: rows AND columns both summarized recursively
+    assert dr.format("{}", dr.reshape(dr.arange(t, 10000), (100, 100))) == \
+        "[[0, 1, 2, .. 94 skipped .., 97, 98, 99],\n" \
+        " [100, 101, 102, .. 94 skipped .., 197, 198, 199],\n" \
+        " [200, 201, 202, .. 94 skipped .., 297, 298, 299],\n" \
+        " .. 94 skipped ..,\n" \
+        " [9700, 9701, 9702, .. 94 skipped .., 9797, 9798, 9799],\n" \
+        " [9800, 9801, 9802, .. 94 skipped .., 9897, 9898, 9899],\n" \
+        " [9900, 9901, 9902, .. 94 skipped .., 9997, 9998, 9999]]"
+
+
 @pytest.test_arrays('shape=(*), uint32, jit')
 def test08_symbolic_print(t):
     b = Buffer()


### PR DESCRIPTION
Assertion-raising counterpart of `drjit.allclose()`, analogous to `numpy.testing.assert_allclose`. On mismatch it reports the mismatch count, maximum absolute and relative differences, and labelled `ACTUAL` / `DESIRED` values, e.g.:

    AssertionError: Arrays are not equal to tolerance rtol=0, atol=0
    Mismatched elements: 1 / 3 (33.3%)
    Max absolute difference: 3
    Max relative difference: 0.6
     ACTUAL: [1, 2, 3]
     DESIRED: [1, 5, 3]

The comparison fuses with upstream pending computation into a single kernel. On success the tensors stay on device and only a single boolean is read back to the host, making this preferable over `numpy.testing.assert_allclose()`.