### PR TITLE
Redesign of the ``drjit.nn`` API; differentiable ``nn.pack()`` function.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -88,6 +88,52 @@ DrJit 1.4.0 (TBA)
   neural networks with optional AdamW-style decoupled weight decay.
   (commit `d205c1 <https://github.com/mitsuba-renderer/drjit/commit/d205c1d4dd57870a54eff0875c2e336a99191317>`__).
 
+- **Redesign of the** :py:mod:`drjit.nn` **API**. Besides
+  :ref:`cooperative vectors <coop_vec>`, the :py:mod:`drjit.nn` API now also
+  accepts regular tensors as inputs through the same ``__call__`` interface.
+  Cooperative vectors better fuse with surrounding computation, while tensor
+  evaluation is convenient for batched evaluation of much larger networks.
+  The two modes are described in detail in the :ref:`neural network
+  documentation <neural_nets>`.
+
+  Every :py:class:`nn.Module <drjit.nn.Module>` is now also a
+  :py:class:`MutableMapping <collections.abc.MutableMapping>` keyed by the
+  full path to each parameter (e.g. ``'layers.0.weights'``), and the
+  optimizer integration is driven through this interface.
+  ``opt.update(net)`` pulls every parameter into the optimizer initially and
+  casts to the correct precision, and ``net.update(opt)`` pushes the updated
+  state back into the network at the start of each step.
+
+  In Dr.Jit 1.1.0, users had to manually cast the packed buffer to
+  :py:class:`Float32 <drjit.cuda.ad.Float32>` for the optimizer and write
+  it back to :py:class:`Float16 <drjit.cuda.ad.Float16>` each iteration:
+
+  .. code-block:: python
+
+     weights, net = nn.pack(net, layout='training')
+     opt = Adam(lr=1e-3, params={'weights': Float32(weights)})
+
+     for i in range(n):
+         weights[:] = Float16(opt['weights'])
+         ...
+
+  This is no longer required:
+
+  .. code-block:: python
+
+     net = nn.pack(net, layout='training')
+     opt = Adam(lr=1e-3)
+     opt.update(net)
+
+     for i in range(n):
+         net.update(opt)
+         ...
+
+- :py:func:`nn.pack() <drjit.nn.pack>` **is now differentiable**. This
+  unlocks matrix-level optimizers such as :py:class:`Muon <drjit.opt.Muon>`
+  on cooperative-vector networks via an in-loop ``nn.pack`` pattern. See
+  the :ref:`neural network documentation <neural_nets>` for details.
+
 - **CUDA Green Context API**: Added :py:class:`drjit.cuda.green_context`, a
   context manager that isolates kernels to a subset of the GPU's streaming
   multiprocessors. See the :ref:`green contexts documentation <green_context>`
@@ -170,6 +216,41 @@ DrJit 1.4.0 (TBA)
   (Dr.Jit commit `861de5 <https://github.com/mitsuba-renderer/drjit/commit/861de5c67b641c4f1ce6f5826c868809fe991416>`__,
   Dr.Jit-Core commit `742ea7 <https://github.com/mitsuba-renderer/drjit-core/commit/742ea73963c9ab96b1fa9fa8fdf040da32e5a459>`__).
 
+**API Breaks**
+
+- ⚠️ :py:func:`nn.pack() <drjit.nn.pack>` and :py:func:`nn.unpack()
+  <drjit.nn.unpack>` **no longer return the shared buffer as the first
+  element of the result tuple**. They now return only the packed/unpacked
+  PyTree with matrix views in place of the input tensors. The underlying
+  buffer remains available via the :py:attr:`MatrixView.buffer
+  <drjit.nn.MatrixView.buffer>` attribute, or, for a packed
+  :py:class:`nn.Module <drjit.nn.Module>`, via the ``'weights'`` entry of
+  the module's mapping interface (i.e. ``net['weights']``).
+
+  Migration:
+
+  .. code-block:: python
+
+     # Before
+     buffer, A_view, b_view = nn.pack(A, b, layout='training')
+     dr.enable_grad(buffer)
+
+     # After
+     A_view, b_view = nn.pack(A, b, layout='training')
+     dr.enable_grad(A_view.buffer)
+
+  For a packed :py:class:`nn.Module <drjit.nn.Module>`:
+
+  .. code-block:: python
+
+     # Before
+     buffer, net = nn.pack(net, layout='training')
+     dr.enable_grad(buffer)
+
+     # After
+     net = nn.pack(net, layout='training')
+     dr.enable_grad(net['weights'])
+
 **Bug Fixes**
 
 - Fixed a bug in :py:meth:`dr.rng().integers() <random.Generator.integers>`
@@ -179,6 +260,10 @@ DrJit 1.4.0 (TBA)
 - Fixed a variable shadowing bug in ``_flatten``/``_unflatten`` that caused
   crashes when flattening PyTrees containing custom ``DRJIT_STRUCT`` types.
   (PR `#482 <https://github.com/mitsuba-renderer/drjit/pull/482>`__).
+
+- Fixed a bug in :py:class:`nn.SinEncode <drjit.nn.SinEncode>` where the
+  per-octave phase offset did not match the documented formula. Code using
+  ``shift=0`` is unaffected.
 
 - Fixed incorrect type names in :py:func:`dr.graphviz_ad() <graphviz_ad>`.
   (commit `0c685e <https://github.com/mitsuba-renderer/drjit/commit/0c685e42d553aad27063c6fd756f5cba91ac503c>`__).

--- a/docs/coop_vec.rst
+++ b/docs/coop_vec.rst
@@ -60,7 +60,7 @@ multiplication.
    b = rng.random(TensorXf, m)
 
    # Pack 'A' and 'b' into a buffer with an optimal layout
-   buffer, A_view, b_view = nn.pack(A, b)
+   A_view, b_view = nn.pack(A, b)
 
    # Create a cooperative vector
    x = nn.CoopVec(... 16 values ...)
@@ -207,11 +207,14 @@ memory layouts for either *inference* (the default) or *training*. You must
 specify ``layout='training'`` if you wish to differentiate matrix
 multiplication in reverse mode.
 
-Following this step, ``A`` and ``b`` have been merged into ``buffer``, and
-``A_view`` and ``b_view`` encode the offset and layout within this larger
-buffer. Matrix views *cannot* be used in arithmetic expressions and are best
-thought of as opaque handles. They only exist to describe the input of the
-matrix-vector multiplication operation explained next.
+Following this step, ``A`` and ``b`` have been merged into a single shared
+buffer, and ``A_view`` and ``b_view`` encode the offset and layout within
+that buffer. The buffer itself is accessible via the
+:py:attr:`MatrixView.buffer <drjit.nn.MatrixView.buffer>` attribute on any
+of the returned views. Matrix views *cannot* be used in arithmetic
+expressions and are best thought of as opaque handles. They only exist to
+describe the input of the matrix-vector multiplication operation explained
+next.
 
 Two other view-related operations be useful in certain situations, please
 see the linked documentation for details.
@@ -260,8 +263,8 @@ propagate derivatives through subsequent operations. Here is an example:
    dr.enable_grad(a)
 
    # Differentiable matrix + bias vector
-   buffer, A_view, b_view = nn.pack(A, b)
-   dr.enable_grad(buffer)
+   A_view, b_view = nn.pack(A, b)
+   dr.enable_grad(A_view.buffer)
 
    # Pack grad-enabled variables into a cooperative vector
    x = nn.CoopVec(a)
@@ -280,12 +283,10 @@ Specific views or cooperative vectors can also be detached via
 
    y = nn.matvec(A_view, dr.detach(x), dr.detach(b_view))
 
-Note that the conversion functions :py:func:`nn.pack() <drjit.nn.pack()>` and
-:py:func:`nn.unpack() <drjit.nn.unpack()>` are *not differentiable*. This is
-intentional: to train a neural network, convert the initial coefficient values
-into training-optimal layout and optimize this representation directly. Doing
-so is more efficient than changing layouts twice in every optimization step
-(once for the weights and once for their derivatives).
+The :py:func:`nn.pack() <drjit.nn.pack()>` function propagates derivatives
+through the packing step when its inputs carry gradient tracking. See the
+:ref:`neural network documentation <neural_nets>` for a discussion of how
+this interacts with different optimizers.
 
 The following AD operations recognize :py:func:`nn.CoopVec
 <drjit.nn.CoopVec>` and :py:func:`nn.MatrixView <drjit.nn.MatrixView>` objects:

--- a/docs/nn.rst
+++ b/docs/nn.rst
@@ -5,16 +5,38 @@
 Neural Networks
 ===============
 
-Dr.Jit's neural network infrastructure builds on :ref:`cooperative vectors
-<coop_vec>`. Please review their documentation before reading this section.
-
 The module :py:mod:`drjit.nn` provides convenient modular abstractions to
-construct, evaluate,  and optimize neural networks. Their design resembles the
+construct, evaluate, and optimize neural networks. Their design resembles the
 PyTorch `nn.Module
 <https://pytorch.org/docs/stable/generated/torch.nn.Module.html>`__ classes.
-The Dr.Jit :py:class:`nn.Module <Module>` class takes a cooperative vector as input
-and produces another cooperative vector. Modules can be chained to form longer
-sequential pipelines.
+
+Neural network declarations in Dr.Jit can be compiled in two fundamentally
+different ways:
+
+- **Tensor mode** is the conventional approach: each layer's matrix
+  multiplication is dispatched to a dedicated matrix multiplication kernel
+  and the surrounding pre- and post-processing is JIT-compiled by Dr.Jit.
+
+- **Cooperative-vector mode** additionally fuses the layer matrix
+  multiplications themselves into the surrounding kernel via the
+  :ref:`cooperative vectors <coop_vec>` API. The result is a single
+  *megakernel* that can evaluate an entire neural network alongside other
+  work (including texture lookups, ray tracing, etc.) without paying
+  the cross-kernel synchronization and memory-traffic cost that a split
+  into multiple kernels would otherwise incur.
+
+  This mode is most interesting when intermediate layer state can comfortably
+  fit into registers. On GPU, layer widths in the range from 16 to 64 are the
+  practical sweet spot. Wider networks (128..256) can work as well but are more
+  challenging to compile into efficient kernels. For large networks, tensor
+  mode tends to win because dedicated matrix multiplication kernels can exploit
+  more of the hardware's matrix-math throughput.
+
+The choice between the two is made at evaluation time by deciding what to
+hand to the network: a tensor selects tensor mode; a :py:class:`CoopVec
+<drjit.nn.CoopVec>` selects cooperative-vector mode after a one-time
+:py:func:`pack` of the weights into a hardware-friendly layout. Most layers
+work unchanged across both modes.
 
 .. warning::
 
@@ -36,6 +58,121 @@ The set of neural network module currently includes:
   :py:class:`nn.Exp <Exp>`, :py:class:`nn.Exp2 <Exp2>`, :py:class:`nn.Tanh <Tanh>`.
 
 - Miscellaneous: :py:class:`nn.Cast <Cast>`, :py:class:`nn.ScaleAdd <ScaleAdd>`.
+
+Accessing and optimizing Module parameters
+------------------------------------------
+
+Every allocated :py:class:`nn.Module <Module>` is a
+:py:class:`MutableMapping <collections.abc.MutableMapping>`. Each key is
+a string that encodes the full path to a parameter tensor inside the
+module tree, separated by dots (for example ``'layers.0.weights'`` or
+``'layers.2.bias'``):
+
+.. code-block:: python
+
+   net = nn.Sequential(nn.Linear(2, 4), nn.ReLU(), nn.Linear(-1, 1)).alloc(TensorXf16, 2)
+
+   list(net.keys())        # ['layers.0.weights', 'layers.0.bias', 'layers.2.weights', 'layers.2.bias']
+   net['layers.0.weights']                              # read a tensor
+   for k, v in net.items():                             # iterate over parameters
+       ...
+   net['layers.0.weights'] = new_weights                # reassign
+
+Writing to ``net[k]`` updates the parameter on the relevant submodule with
+casts if needed, e.g., when a single-precision optimizer modifies a
+half-precision model.
+
+The same mapping interface drives parameter transfer with an optimizer. An
+optimizer pulls every parameter in once initially, and the user's training
+loop pushes the optimizer's updated state back into the network before
+each forward pass:
+
+.. code-block:: python
+
+   opt = Adam(lr=1e-3)
+   opt.update(net)            # pull every parameter into the optimizer (once)
+
+   for i in range(n_iter):
+       net.update(opt)        # push the optimizer state back into the net
+       y = net(x)
+       loss = ...
+       dr.backward(loss)
+       opt.step()
+
+After the initial ``opt.update(net)`` the optimizer holds the authoritative
+copy of the parameters. Do not call ``opt.update(net)`` a second time later
+on, as it would overwrite the just-computed step.
+
+Optimization in tensor mode
+---------------------------
+
+Tensor mode is the simplest case: each layer's 2D weight tensor is already
+a parameter in the module mapping, and the optimizer attaches to those
+tensors directly. Any optimizer works:
+
+.. code-block:: python
+
+   net = nn.Sequential(...).alloc(TensorXf16, batch_size)
+
+   opt = Adam(lr=0.02)
+   opt.update(net)
+
+   for i in range(n_iter):
+       net.update(opt)
+       y = net(x_tensor)
+       loss = ...
+       dr.backward(loss); opt.step()
+
+For a complete training setup that also includes 1D parameters (biases),
+pair :py:class:`Muon <drjit.opt.Muon>` on the 2D weights with
+:py:class:`AdamW <drjit.opt.AdamW>` on everything else — see the
+:py:class:`Muon <drjit.opt.Muon>` docstring for a worked example.
+
+Optimization in cooperative-vector mode
+---------------------------------------
+
+Cooperative-vector mode adds a complication: hardware matrix-vector
+operations want their weights in a vendor-specific *packed* layout, not
+the row-major form the per-layer 2D tensors use. The conversion happens
+through a call to :py:func:`pack(net) <pack>`, which produces a packed
+module whose mapping collapses to a single ``'weights'`` entry pointing
+at the packed buffer.
+
+**Where** in the training loop :py:func:`pack` runs determines which view
+the optimizer sees. Element-wise optimizers are happy with the packed
+buffer, so :py:func:`pack` can be called once, outside the loop:
+
+.. code-block:: python
+
+   packed_net = nn.pack(net, layout='training')
+
+   opt = Adam(lr=1e-3)
+   opt.update(packed_net)
+
+   for i in range(n_iter):
+       packed_net.update(opt)
+       y = packed_net(nn.CoopVec(x))
+       loss = ...
+       dr.backward(loss); opt.step()
+
+Matrix-level optimizers such as :py:class:`Muon <drjit.opt.Muon>` need to
+see each layer's weights as a 2D matrix, so :py:func:`pack` is called
+*inside* the loop on the unpacked module. :py:func:`pack` is
+differentiable, so gradients on the packed buffer flow back through the
+layout transform to the per-layer 2D weight tensors and into the
+optimizer's state:
+
+.. code-block:: python
+
+   opt = Muon(lr=0.02)
+   opt.update(net)
+
+   for i in range(n_iter):
+       net.update(opt)
+       packed_net = nn.pack(net, layout='training')
+       y = packed_net(nn.CoopVec(x))
+       loss = ...
+       dr.backward(loss); opt.step()
 
 Example
 -------
@@ -69,7 +206,8 @@ mixed-precision training.
     ref = TensorXf(iio.imread("https://d38rqfq1h7iukm.cloudfront.net/media/uploads/wjakob/2024/06/wave-128.png") / 256)
     tex = Texture2f(ref)
 
-    # Establish the network structure
+    # Establish the network structure. Networks with an encoding
+    # layer do not need biases, which simplifies the architecture.
     net = nn.Sequential(
         nn.TriEncode(16, 0.2),
         nn.Cast(Float16),
@@ -94,11 +232,13 @@ mixed-precision training.
     )
 
     # Convert to training-optimal layout
-    weights, net = nn.pack(net, layout='training')
+    net = nn.pack(net, layout='training')
     print(net)
 
-    # Optimize a single-precision copy of the parameters
-    opt = Adam(lr=1e-3, params={'weights': Float32(weights)})
+    # The optimizer discovers the parameter via the module's mapping
+    # interface and keeps its own single-precision copy of the packed buffer.
+    opt = Adam(lr=1e-3)
+    opt.update(net)
 
     # This is an adaptive mixed-precision (AMP) optimization, where a half
     # precision computation runs within a larger single-precision program.
@@ -108,8 +248,8 @@ mixed-precision training.
     res = 256
 
     for i in tqdm(range(40000)):
-        # Update network state from optimizer
-        weights[:] = Float16(opt['weights'])
+        # Push the latest optimizer state back into the network (Float32 -> Float16).
+        net.update(opt)
 
         # Generate jittered positions on [0, 1]^2
         t = dr.arange(Float32, res)
@@ -224,7 +364,9 @@ using a hash grid encoding.
     # Establish the network structure.
     # In contrast to the previous example, we use a HashEncodingLayer, referencing
     # the previously created hash grid. Its parameters will not be part of the
-    # packed weights, and have to be handled separately.
+    # packed weights, and have to be handled separately. The ``prefix`` keeps
+    # the packed weights from colliding with the hash grid parameters when both
+    # are handed to a single optimizer.
     net = nn.Sequential(
         nn.HashEncodingLayer(enc),
         nn.Cast(Float16),
@@ -235,26 +377,23 @@ using a hash grid encoding.
         nn.Linear(-1, -1, bias=False),
         nn.LeakyReLU(),
         nn.Linear(-1, 3, bias=False),
-        nn.Exp()
+        nn.Exp(),
+        prefix='mlp'
     )
 
-    # Instantiate the network for a specific backend + input size
+    # Instantiate the network for a specific backend + input size.
     net = net.alloc(TensorXf16, 2, rng=rng)
 
-    # Convert to training-optimal layout
-    weights, net = nn.pack(net, layout='training')
+    # Convert to training-optimal layout.
+    net = nn.pack(net, layout='training')
     print(net)
 
-    # Optimize a single-precision copy of the parameters.
-    # In addition to the network weights, we also add the parameters of the
-    # encoding.
-    opt = Adam(
-        lr=1e-3,
-        params={
-            "mlp.weights": Float32(weights),
-            "enc.params": Float32(enc.params),
-        },
-    )
+    # Optimize a single-precision copy of the parameters. The optimizer picks
+    # up ``mlp.weights`` from ``net`` through the mapping interface and we
+    # add the encoding parameters alongside.
+    opt = Adam(lr=1e-3)
+    opt.update(net)
+    opt['enc.params'] = Float32(enc.params)
 
     # This is an adaptive mixed-precision (AMP) optimization, where a half
     # precision computation runs within a larger single-precision program.
@@ -264,9 +403,9 @@ using a hash grid encoding.
     res = 256
 
     for i in tqdm(range(40000)):
-        # Update network state from optimizer
-        weights[:] = Float16(opt['mlp.weights'])
-        # Update the encoding parameters as well
+        # Push the latest network weights back into the net (Float32 -> Float16).
+        net.update(opt)
+        # The encoding parameters still have to be written back manually.
         enc.params[:] = Float16(opt['enc.params'])
 
         # Generate jittered positions on [0, 1]^2

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -873,9 +873,6 @@ section <neural_nets>` for an introduction.
 
 .. autoclass:: Sequential
 
-   .. automethod:: __len__
-   .. automethod:: __getitem__
-
 .. autoclass:: Linear
 .. autoclass:: ReLU
 .. autoclass:: LeakyReLU

--- a/drjit/nn.py
+++ b/drjit/nn.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 import drjit
 import sys
+from collections.abc import MutableMapping
 from .hashgrid import HashGridEncoding, PermutoEncoding
 from . import hashgrid
 
 if sys.version_info < (3, 11):
-    from typing_extensions import Tuple, Sequence, Union, Type, TypeAlias, Optional, Any, overload
+    from typing_extensions import Tuple, Sequence, Union, Type, TypeAlias, Optional, Any, Dict, Iterator, TypeVar
 else:
-    from typing import Tuple, Sequence, Union, Type, TypeAlias, Optional, Any, overload
+    from typing import Tuple, Sequence, Union, Type, TypeAlias, Optional, Any, Dict, Iterator, TypeVar
 
 # Import classes/functions from C++ extension
 MatrixView = drjit.detail.nn.MatrixView
@@ -19,19 +20,88 @@ view = drjit.detail.nn.view
 cast = drjit.detail.nn.cast
 T = drjit.detail.nn.T
 
+
 TensorOrViewOrNone: TypeAlias = Union[
     drjit.ArrayBase,
     MatrixView,
     None
 ]
 
-class Module:
+# Type variable for activation-like modules whose ``__call__`` preserves the
+# input type (either :class:`CoopVec` or a Dr.Jit tensor).
+_InputT = TypeVar('_InputT', CoopVec, drjit.ArrayBase)
+
+
+def _walk_params(root: 'Module', prefix: str):
+    """Walk a Module's ``DRJIT_STRUCT`` tree and collect parameter leaves.
+
+    Returns ``(params, packed_key)`` where ``params`` maps dotted paths to
+    ``(owner, attr)`` pairs that locate each leaf on its parent module, and
+    ``packed_key`` is the key whose entry backs a :func:`pack`-produced
+    buffer (or ``None`` in tensor mode).
+    """
+    params: Dict[str, Tuple[Any, str]] = {}
+    packed_key: Optional[str] = None
+
+    def visit_module(mod: 'Module', sub_prefix: str) -> None:
+        nonlocal packed_key
+        if getattr(mod, '_packed_buffer', None) is not None:
+            key = f'{sub_prefix}.weights' if sub_prefix else 'weights'
+            params[key] = (mod, '_packed_buffer')
+            packed_key = key
+            return
+
+        struct = getattr(type(mod), 'DRJIT_STRUCT', None)
+        if struct is None:
+            return
+
+        for name in struct:
+            sub_key = f'{sub_prefix}.{name}' if sub_prefix else name
+            visit(getattr(mod, name, None), sub_key, mod, name)
+
+    def visit(value: Any, key: str, owner: Any, attr: Optional[str]) -> None:
+        if value is None:
+            return
+        if isinstance(value, Module):
+            visit_module(value, key)
+        elif isinstance(value, (tuple, list)):
+            for i, item in enumerate(value):
+                visit(item, f'{key}.{i}', owner=None, attr=None)
+        elif isinstance(value, MatrixView):
+            return
+        elif isinstance(value, drjit.ArrayBase) and attr is not None:
+            params[key] = (owner, attr)
+
+    visit_module(root, prefix)
+    return params, packed_key
+
+class Module(MutableMapping):
     """
     This is the base class of a modular set of operations that make
     the specification of neural network architectures more convenient.
 
     Module subclasses are :ref:`PyTrees <pytrees>`, which means that various
     Dr.Jit operations can automatically traverse them.
+
+    Every allocated :class:`Module` additionally behaves as a
+    :class:`collections.abc.MutableMapping` keyed by dotted parameter paths
+    (e.g., ``'layers.0.weights'``). This mirrors the :class:`drjit.opt.Optimizer`
+    interface and enables symmetric parameter transfer:
+
+    .. code-block:: python
+
+       opt = Adam(lr=1e-3)
+       opt.update(net)       # pull every parameter into the optimizer (once)
+
+       for i in range(n):
+           net.update(opt)   # push optimizer state back into the net
+           ...
+
+    After attach, the optimizer is the source of truth: ``opt.update(net)``
+    must not be called again. On a packed module the mapping exposes a single
+    ``'weights'`` entry whose underlying buffer is referenced by the per-layer
+    :class:`MatrixView` instances; writes to that entry are in-place so the
+    views remain valid.
 
     Constructing a neural network generally involves the following pattern:
 
@@ -48,14 +118,12 @@ class Module:
        net = net.alloc(TensorXf16, 2)
 
        # 3. Pack coefficients into a training-optimal layout
-       coeffs, net = nn.pack(net, layout='training')
+       net = nn.pack(net, layout='training')
 
     Network evaluation expects a :ref:`cooperative vector <coop_vec>` as input
     (i.e., ``net(nn.CoopVec(...))``) and returns another cooperative vector.
-    The ``coeffs`` buffer contains all weight/bias data in training-optimal
-    format and can be optimized, which will directly impact the packed network
-    ``net`` that references this buffer.
     """
+
     def __call__(self, arg: CoopVec, /) -> CoopVec:
         """
         Evaluate the model with an input cooperative vector and return the result.
@@ -75,7 +143,8 @@ class Module:
         """
         return self, size
 
-    def alloc(self, dtype: Type[drjit.ArrayBase], size: int = -1, rng: Optional[drjit.random.Generator] = None) -> Module:
+    def alloc(self, dtype: Type[drjit.ArrayBase], size: int = -1,
+              rng: Optional[drjit.random.Generator] = None) -> Module:
         """
         Returns a new instance of the model with allocated weights.
 
@@ -113,16 +182,74 @@ class Module:
     def __repr__(self) -> str:
         return f"{type(self).__name__}()"
 
-class Sequential(Module, Sequence[Module]):
+    # ---- MutableMapping interface ---------------------------------------
+
+    def _params_cache(self) -> Dict[str, Tuple[Any, str]]:
+        d = getattr(self, '_params', None)
+        if d is None:
+            params, packed_key = _walk_params(self, getattr(self, 'prefix', ''))
+            self._params = params
+            self._packed_key = packed_key
+            d = params
+        return d
+
+    def __getitem__(self, key: str) -> drjit.ArrayBase:
+        slot = self._params_cache().get(key)
+        if slot is None:
+            raise KeyError(key)
+        owner, attr = slot
+        return getattr(owner, attr)
+
+    def __setitem__(self, key: str, value: drjit.ArrayBase) -> None:
+        slot = self._params_cache().get(key)
+        if slot is None:
+            raise KeyError(key)
+        owner, attr = slot
+
+        if key == self._packed_key:
+            # MatrixViews on the sub-layers point into this buffer's memory;
+            # a reference swap would leave them dangling.
+            getattr(owner, attr)[:] = value
+            return
+
+        existing = getattr(owner, attr)
+        if type(value) is not type(existing):
+            value = type(existing)(value)
+        setattr(owner, attr, value)
+
+    def __delitem__(self, key: str) -> None:
+        raise TypeError(
+            "drjit.nn.Module: parameter keys cannot be deleted via the "
+            "mapping interface."
+        )
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._params_cache())
+
+    def __len__(self) -> int:
+        return len(self._params_cache())
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._params_cache()
+
+class Sequential(Module):
     """
     This model evaluates provided arguments ``arg[0]``, ``arg[1]``, ..., in sequence.
+
+    The optional ``prefix`` keyword is prepended to every key exposed through
+    the :class:`MutableMapping` interface (e.g., ``'mlp.layers.0.weights'``
+    instead of ``'layers.0.weights'``). This is useful when sharing a single
+    optimizer across multiple networks. The prefix is retained through
+    :func:`pack`.
     """
-    DRJIT_STRUCT = { 'layers' : tuple }
+    DRJIT_STRUCT = { 'layers' : tuple, 'prefix': str }
 
     layers: tuple[Module, ...]
+    prefix: str
 
-    def __init__(self, *args: Module):
+    def __init__(self, *args: Module, prefix: str = ''):
         self.layers = args
+        self.prefix = prefix
 
     def __call__(self, arg: CoopVec, /) -> CoopVec:
         for l in self.layers:
@@ -134,15 +261,7 @@ class Sequential(Module, Sequence[Module]):
         for l in self.layers:
             l_new, size = l._alloc(dtype, size, rng)
             result.append(l_new)
-        return Sequential(*result), size
-
-    def __len__(self):
-        """Return the number of contained models"""
-        return len(self.layers)
-
-    def __getitem__(self, index: int, /) -> Module: # type: ignore
-        """Return the model at position ``index``"""
-        return self.layers[index]
+        return Sequential(*result, prefix=self.prefix), size
 
     def __repr__(self) -> str:
         s = 'Sequential(\n'
@@ -165,10 +284,11 @@ class ReLU(Module):
 
        \mathrm{ReLU}(x) = \mathrm{max}\{x, 0\}.
 
+    Accepts both :class:`CoopVec` and tensor inputs.
     """
 
     DRJIT_STRUCT = { }
-    def __call__(self, arg: CoopVec, /) -> CoopVec:
+    def __call__(self, arg: _InputT, /) -> _InputT:
         return drjit.maximum(arg, 0)
 
 class LeakyReLU(Module):
@@ -183,13 +303,15 @@ class LeakyReLU(Module):
           x,&\mathrm{if}\ x\ge 0,\\
           \texttt{negative\_slope}\cdot x,&\mathrm{otherwise}.
        \end{cases}
+
+    Accepts both :class:`CoopVec` and tensor inputs.
     """
 
     DRJIT_STRUCT = { 'negative_slope': Union[float, drjit.ArrayBase] }
     def __init__(self, negative_slope: Union[float, drjit.ArrayBase] = 1e-2):
         self.negative_slope = negative_slope
 
-    def __call__(self, arg: CoopVec, /) -> CoopVec:
+    def __call__(self, arg: _InputT, /) -> _InputT:
         return drjit.maximum(arg, 0) + drjit.minimum(arg, 0.0) * self.negative_slope
 
 
@@ -202,9 +324,10 @@ class Exp2(Module):
        \mathrm{Exp2}(x) = 2^x
 
     On the CUDA backend, this function directly maps to an efficient native GPU instruction.
+    Accepts both :class:`CoopVec` and tensor inputs.
     """
     DRJIT_STRUCT = { }
-    def __call__(self, arg: CoopVec, /) -> CoopVec:
+    def __call__(self, arg: _InputT, /) -> _InputT:
         return drjit.exp2(arg)
 
 class Exp(Module):
@@ -214,9 +337,11 @@ class Exp(Module):
     .. math::
 
        \mathrm{Exp}(x) = e^x
+
+    Accepts both :class:`CoopVec` and tensor inputs.
     """
     DRJIT_STRUCT = { }
-    def __call__(self, arg: CoopVec, /) -> CoopVec:
+    def __call__(self, arg: _InputT, /) -> _InputT:
         return drjit.exp2(arg * (1 / drjit.log(2)))
 
 class Tanh(Module):
@@ -228,9 +353,10 @@ class Tanh(Module):
        \mathrm{Tanh}(x) = \frac{\exp(x)-\exp(-x)}{\exp(x)+\exp(-x)}
 
     On the CUDA backend, this function directly maps to an efficient native GPU instruction.
+    Accepts both :class:`CoopVec` and tensor inputs.
     """
     DRJIT_STRUCT = { }
-    def __call__(self, arg: CoopVec, /) -> CoopVec:
+    def __call__(self, arg: _InputT, /) -> _InputT:
         return drjit.tanh(arg)
 
 class ScaleAdd(Module):
@@ -242,6 +368,8 @@ class ScaleAdd(Module):
     .. math::
 
        \mathrm{ScaleAdd}(x) = x\cdot\texttt{scale} + \texttt{offset}
+
+    Accepts both :class:`CoopVec` and tensor inputs.
     """
     DRJIT_STRUCT = {'scale': Union[None, float, int, drjit.ArrayBase],
                     'offset': Union[None, float, int, drjit.ArrayBase]}
@@ -249,21 +377,24 @@ class ScaleAdd(Module):
                  offset: Union[float, int, drjit.ArrayBase, None] = None):
         self.scale = scale
         self.offset = offset
-    def __call__(self, arg: CoopVec, /) -> CoopVec:
+    def __call__(self, arg: _InputT, /) -> _InputT:
         if not self.scale or not self.offset:
             raise Exception("drjit.nn.ScaleAdd(): you must set a scale and offset!")
         return drjit.fma(arg, self.scale, self.offset)
 
 class Cast(Module):
     """
-    Cast the input cooperative vector to a different precision. Should be
-    instantiated with the desired element type, e.g. ``Cast(drjit.cuda.ad.Float32)``
+    Cast the input to a different precision. Should be instantiated with the
+    desired element type, e.g. ``Cast(drjit.cuda.ad.Float32)``. Accepts both
+    :class:`CoopVec` and tensor inputs.
     """
     DRJIT_STRUCT = { 'dtype': Optional[Type[drjit.ArrayBase]] }
     def __init__(self, dtype: Optional[Type[drjit.ArrayBase]] = None):
         self.dtype = dtype
-    def __call__(self, arg: CoopVec, /) -> CoopVec:
-        return cast(arg, self.dtype)
+    def __call__(self, arg: _InputT, /) -> _InputT:
+        if isinstance(arg, CoopVec):
+            return cast(arg, self.dtype)
+        return drjit.tensor_t(self.dtype)(arg)
     def __repr__(self):
         return f'Cast(dtype={self.dtype.__name__})'
 
@@ -311,21 +442,37 @@ class Linear(Module):
         s += ')'
         return s
 
-    def __call__(self, arg: CoopVec, /) -> CoopVec:
-        if self.weights is None:
+    def __call__(self, arg: _InputT, /) -> _InputT:
+        w = self.weights
+        if w is None:
             raise RuntimeError(
-                "Uninitialized network. Call 'net = net.alloc(""<Tensor type>"
-                ")' to initialize the weight storage first. Following this, "
-                "use 'drjit.nn.pack()' to transform the network into an "
-                "optimal layout for evaluation."
+                "drjit.nn.Linear: uninitialized network. Call "
+                "'net = net.alloc(<Tensor type>)' to initialize the weight "
+                "storage first."
             )
-        elif not isinstance(self.weights, MatrixView) or \
-           (self.bias is not None and not isinstance(self.bias, MatrixView)):
+
+        if isinstance(arg, CoopVec):
+            if not isinstance(w, MatrixView):
+                raise RuntimeError(
+                    "drjit.nn.Linear: cooperative-vector evaluation requires "
+                    "packed weights. Call 'drjit.nn.pack(net)' to transform "
+                    "the network into a cooperative-vector layout."
+                )
+            return matvec(w, arg, self.bias)
+
+        if isinstance(w, MatrixView):
             raise RuntimeError(
-                "Uninitialized network. Use 'drjit.nn.pack()' to transform"
-                "the network into an optimal layout for evaluation."
+                "drjit.nn.Linear: tensor-mode evaluation requires unpacked 2D "
+                "weights. Either wrap the input as 'nn.CoopVec(...)' or "
+                "construct a fresh unpacked module (without calling "
+                "'drjit.nn.pack()')."
             )
-        return matvec(self.weights, arg, self.bias)
+
+        y = w @ arg
+        if self.bias is not None:
+            bias = self.bias
+            y = y + drjit.reshape(bias, (bias.shape[0], 1))
+        return y
 
     def _alloc(self, dtype: Type[drjit.ArrayBase], size : int, rng: drjit.random.Generator, /) -> Tuple[Module, int]:
         if not drjit.is_tensor_v(dtype):
@@ -350,15 +497,86 @@ class Linear(Module):
             result.bias = drjit.zeros(dtype, out_features)
         return result, out_features
 
-def _sincos_tri(t: T) -> tuple[T, T]:
-    """Implementation detail of the TriEncode class"""
+def _sincos_tri(t):
+    """Triangular sine/cosine approximations with period 1."""
     s = t - .25
-    st = s - drjit.round(s)
-    ct = t - drjit.round(t)
-    return (
-        drjit.fma(drjit.abs(st), -4, 1),
-        drjit.fma(drjit.abs(ct), -4, 1)
-    )
+    return (drjit.fma(drjit.abs(s - drjit.round(s)), -4, 1),
+            drjit.fma(drjit.abs(t - drjit.round(t)), -4, 1))
+
+
+def _tri_encode_coopvec(arg, O, shift):
+    r = []
+    for a in list(arg):
+        for i in range(O):
+            r += _sincos_tri(drjit.fma(a, 2 ** i, shift * i))
+    return CoopVec(r)
+
+
+def _tri_encode_tensor(arg, O, shift):
+    C, N = arg.shape
+    tensor_tp = type(arg)
+    out = drjit.empty(tensor_tp, (C * 2 * O, N))
+    for i in range(O):
+        s, c = _sincos_tri(drjit.fma(arg, 2.0 ** i, shift * i))
+        out[2 * i::2 * O, :] = s.array
+        out[2 * i + 1::2 * O, :] = c.array
+    return out
+
+
+def _sin_encode_rotations(shift, O):
+    """Precompute the per-octave rotation following each double-angle step.
+
+    Going from octave i-1 to i, the target angle is
+    ``θ_i = 2 θ_{i-1} + β_i`` with ``β_i = 2π · s · (2 - i)``. Returns the
+    list ``[(sin β_1, cos β_1), ..., (sin β_{O-1}, cos β_{O-1})]``, or
+    ``None`` when the rotation is identically zero (``shift == 0`` collapses
+    to the pure double-angle recurrence).
+    """
+    if O <= 1 or shift == 0:
+        return None
+    return [drjit.sincos(2 * drjit.pi * shift * (2 - i)) for i in range(1, O)]
+
+
+def _sin_encode_step(s, c, rot):
+    # Double-angle on (s, c), then an optional fixed rotation by the next β_i.
+    s2 = 2 * s
+    s, c = s2 * c, drjit.fma(-s2, s, 1)
+    if rot is not None:
+        sb, cb = rot
+        s, c = drjit.fma(s, cb, c * sb), drjit.fma(c, cb, -s * sb)
+    return s, c
+
+
+def _sin_encode_coopvec(arg, O, shift):
+    if O == 0:
+        return CoopVec([])
+    rots = _sin_encode_rotations(shift, O)
+    r = []
+    for a in list(arg):
+        s, c = drjit.sincos(a * (2 * drjit.pi))
+        r += [s, c]
+        for i in range(1, O):
+            s, c = _sin_encode_step(s, c, rots[i - 1] if rots else None)
+            r += [s, c]
+    return CoopVec(r)
+
+
+def _sin_encode_tensor(arg, O, shift):
+    C, N = arg.shape
+    tensor_tp = type(arg)
+    if O == 0:
+        return drjit.zeros(tensor_tp, (0, N))
+    out = drjit.empty(tensor_tp, (C * 2 * O, N))
+    s, c = drjit.sincos(arg * (2 * drjit.pi))
+    out[0::2 * O, :] = s.array
+    out[1::2 * O, :] = c.array
+    rots = _sin_encode_rotations(shift, O)
+    for i in range(1, O):
+        s, c = _sin_encode_step(s, c, rots[i - 1] if rots else None)
+        out[2 * i::2 * O, :] = s.array
+        out[2 * i + 1::2 * O, :] = c.array
+    return out
+
 
 class TriEncode(Module):
     r"""
@@ -368,11 +586,11 @@ class TriEncode(Module):
     .. math::
 
        x\mapsto \begin{bmatrix}
-           \sin_\triangle(2^0\,x)\\
-           \cos_\triangle(2^0\,x)\\
+           \sin_\triangle(2^0\,x + 0\cdot s)\\
+           \cos_\triangle(2^0\,x + 0\cdot s)\\
            \vdots\\
-           \cos_\triangle(2^{n-1}\, x)\\
-           \sin_\triangle(2^{n-1}\, x)
+           \sin_\triangle(2^{n-1}\, x + (n-1)\cdot s)\\
+           \cos_\triangle(2^{n-1}\, x + (n-1)\cdot s)
        \end{bmatrix}
 
     where
@@ -385,7 +603,7 @@ class TriEncode(Module):
 
     .. math::
 
-       \sin_\triangle(x) = \cos_\triangle(x-1/4)
+       \sin_\triangle(x) = \cos_\triangle(x-1/4).
 
     The value :math:`n` refers to the number of *octaves*. This layer increases
     the dimension by a factor of :math:`2n`.
@@ -394,10 +612,15 @@ class TriEncode(Module):
     :math:`[0, 1]`, it is advisable that you reduce it to this range to avoid
     losing information.
 
-    Minima/maxima of higher frequency components conincide on a regular
+    Minima/maxima of higher frequency components coincide on a regular
     lattice, which can lead to reduced fitting performance at those locations.
-    Specify the optional parameter ``shift`` to phase-shift the :math:`i`-th
-    frequency by :math:`2\,\pi\,\mathrm{shift}` to avoid this behavior.
+    Specify the optional ``shift`` parameter :math:`s` (in *fractional
+    periods*, so that ``shift=0.25`` is a quarter period) to phase-shift the
+    :math:`i`-th octave by :math:`i\cdot s` and avoid this.
+
+    Accepts both :class:`CoopVec` and 2D tensor inputs (batched evaluation).
+    For a tensor of shape ``(C, N)`` with ``N`` independent samples, the
+    output has shape ``(2\,n\,C, N)``.
 
     The following plot shows the first two octaves applied to the linear
     function on :math:`[0, 1]` (without shift).
@@ -428,14 +651,10 @@ class TriEncode(Module):
     def __repr__(self) -> str:
         return f'TriEncode(octaves={self.octaves}, shift={self.shift}, in_channels={self.channels}, out_features={self.channels*self.octaves*2})'
 
-    def __call__(self, arg: CoopVec, /) -> CoopVec:
-        args, r = list(arg), list()
-        for arg in args:
-            for i in range(self.octaves):
-                s, c = _sincos_tri(drjit.fma(arg, 2**i, self.shift*i))
-                r.append(s)
-                r.append(c)
-        return CoopVec(r)
+    def __call__(self, arg: _InputT, /) -> _InputT:
+        if isinstance(arg, CoopVec):
+            return _tri_encode_coopvec(arg, self.octaves, self.shift)
+        return _tri_encode_tensor(arg, self.octaves, self.shift)
 
 
 class SinEncode(Module):
@@ -446,13 +665,12 @@ class SinEncode(Module):
     .. math::
 
        x\mapsto \begin{bmatrix}
-           \sin(2^0\, 2\pi x)\\
-           \cos(2^0\, 2\pi x)\\
+           \sin\bigl(2\pi(2^0\,x + 0\cdot s)\bigr)\\
+           \cos\bigl(2\pi(2^0\,x + 0\cdot s)\bigr)\\
            \vdots\\
-           \sin(2^{n-1}\, 2\pi x)\\
-           \cos(2^{n-1}\, 2\pi x)\\
+           \sin\bigl(2\pi(2^{n-1}\,x + (n-1)\cdot s)\bigr)\\
+           \cos\bigl(2\pi(2^{n-1}\,x + (n-1)\cdot s)\bigr)
        \end{bmatrix}
-
 
     The value :math:`n` refers to the number of *octaves*. This layer increases
     the dimension by a factor of :math:`2n`.
@@ -461,10 +679,15 @@ class SinEncode(Module):
     :math:`[0, 1]`, it is advisable that you reduce it to this range to avoid
     losing information.
 
-    Minima/maxima of higher frequency components conincide on a regular
+    Minima/maxima of higher frequency components coincide on a regular
     lattice, which can lead to reduced fitting performance at those locations.
-    Specify the optional parameter ``shift`` to phase-shift the :math:`i`-th
-    frequency by :math:`\mathrm{shift}` radians to avoid this behavior.
+    Specify the optional ``shift`` parameter :math:`s` (in *fractional
+    periods*, so that ``shift=0.25`` is a quarter period) to phase-shift the
+    :math:`i`-th octave by :math:`i\cdot s` and avoid this.
+
+    Accepts both :class:`CoopVec` and 2D tensor inputs (batched evaluation).
+    For a tensor of shape ``(C, N)`` with ``N`` independent samples, the
+    output has shape ``(2\,n\,C, N)``.
 
     The following plot shows the first two octaves applied to the linear
     function on :math:`[0, 1]` (without shift).
@@ -480,47 +703,25 @@ class SinEncode(Module):
       :align: center
     """
 
-    DRJIT_STRUCT = { 'octaves' : int, 'shift': Union[tuple, None], 'channels': int }
+    DRJIT_STRUCT = { 'octaves' : int, 'shift': float, 'channels': int }
 
     def __init__(self, octaves: int = 0, shift: float = 0) -> None:
         self.octaves = octaves
+        self.shift = shift
         self.channels = -1
 
-        if shift == 0:
-            self.shift = None
-        else:
-            self.shift = (drjit.sin(shift * 2 * drjit.pi),
-                          drjit.cos(shift * 2 * drjit.pi))
-
     def _alloc(self, dtype: Type[drjit.ArrayBase], size : int, rng: drjit.random.Generator, /) -> Tuple[Module, int]:
-        r = SinEncode(self.octaves)
+        r = SinEncode(self.octaves, self.shift)
         r.channels = size
-        r.shift = self.shift
         return r, size * self.octaves * 2
 
     def __repr__(self) -> str:
         return f'SinEncode(octaves={self.octaves}, shift={self.shift}, in_channels={self.channels}, out_features={self.channels*self.octaves*2})'
 
-    def __call__(self, arg: CoopVec, /) -> CoopVec:
-        args, r = list(arg), list()
-        for arg in args:
-            s, c = drjit.sincos(arg * 2 * drjit.pi)
-            r.append(s)
-            r.append(c)
-            for _ in range(1, self.octaves):
-                # Recurrence for double angle sine/cosine
-                s2 = 2 * s
-                s, c = s2 * c, drjit.fma(-s2, s, 1)
-                r.append(s)
-                r.append(c)
-
-                if self.shift:
-                    # Recurrence for sine/cosine angle addition
-                    ss, cs = self.shift
-                    s, c = drjit.fma(s, cs,  c*ss), \
-                           drjit.fma(c, cs, -s*ss)
-
-        return CoopVec(r)
+    def __call__(self, arg: _InputT, /) -> _InputT:
+        if isinstance(arg, CoopVec):
+            return _sin_encode_coopvec(arg, self.octaves, self.shift)
+        return _sin_encode_tensor(arg, self.octaves, self.shift)
 
 class HashEncodingLayer(Module):
     """

--- a/drjit/opt.py
+++ b/drjit/opt.py
@@ -248,7 +248,13 @@ class Optimizer(Generic[Extra], MutableMapping[str, dr.ArrayBase]):
 
         if not (dr.is_diff_v(value) and dr.is_float_v(value)):
             raise TypeError(
-                f'Optimizer.__setitem__(): parameter "{key}" is not differentiable!'
+                f'Optimizer.__setitem__(): cannot register parameter "{key}" of '
+                f'type "{type(value).__name__}". Dr.Jit optimizers expect a '
+                f'differentiable Dr.Jit array or tensor. If you intended to '
+                f'register a PyTree (tuple, list, dict, dataclass, '
+                f'DRJIT_STRUCT, ...), note that nested structures are not '
+                f'supported and must be flattened into individual entries '
+                f'before registration.'
             )
 
         if dr.width(value) == 0:
@@ -262,12 +268,12 @@ class Optimizer(Generic[Extra], MutableMapping[str, dr.ArrayBase]):
         # Ensure that this copy is not in symbolic/literal form
         dr.make_opaque(value)
 
-        # Reattach the copy to the AD graph
-        dr.enable_grad(value)
-
+        # Do cast _before_ enable_grad so that `value` will receive gradients
         promoted = self.promote_fp16 and dr.type_v(value) == dr.VarType.Float16
         if promoted:
             value = dr.float32_array_t(value)(value)
+
+        dr.enable_grad(value)
 
         if prev is not None and prev[0].shape == value.shape:
             self.state[key] = value, promoted, *prev[2:]
@@ -1504,6 +1510,40 @@ class Muon(Optimizer):
 
     This class is a Dr.Jit port of the reference PyTorch implementation
     by Keller Jordan et al.
+
+    When handed a :py:class:`drjit.nn.Module` via :py:meth:`update`, Muon
+    silently drops every non-2D entry (biases, scalars, etc.) — these are
+    meant to be optimized by a standard rule such as :py:class:`AdamW`
+    attached to the same module. The two optimizers then cover disjoint
+    subsets of ``net.keys()``, and a single ``net.update(opt)`` call per
+    optimizer at the top of the training loop keeps the network parameters
+    synchronized:
+
+    .. code-block:: python
+
+       muon = Muon(lr=0.02)
+       muon.update(net)
+
+       adamw = AdamW(lr=1e-3)
+       adamw.update({k: net[k] for k in net if len(net[k].shape) == 1})
+
+       for i in range(n_iter):
+           net.update(muon)
+           net.update(adamw)
+           y = net(x_tensor)
+           loss = ...
+           dr.backward(loss)
+           muon.step()
+           adamw.step()
+
+    For :py:func:`drjit.nn.pack`-based cooperative-vector networks, hand
+    ``Muon`` the *unpacked* module and call :py:func:`drjit.nn.pack` inside
+    the training loop. The matrix-pack path is differentiable, so gradients
+    on the packed buffer flow back through the layout transform to the
+    per-layer 2D weight tensors and from there into Muon's
+    single-precision state.
+    See the :ref:`neural network documentation <neural_nets>` for the full
+    side-by-side flows.
     """
 
     def __init__(self, lr, params=None, *, momentum=0.95, nesterov=True,
@@ -1584,6 +1624,12 @@ class Muon(Optimizer):
         new_value = dr.fma(neg_lr, u_flat, retained)
 
         return new_value, (m_next, shape)
+
+    def _filter(self, params):
+        # Muon is only meaningful on 2D weight matrices; drop scalar, 1D
+        # (biases), or higher-rank entries so that ``update(net)`` can be
+        # called on a whole module without the user having to hand-filter.
+        return {k: v for k, v in params.items() if len(v.shape) == 2}
 
     def _reset(self, key, value, promoted):
         if len(value.shape) != 2:

--- a/include/drjit/extra.h
+++ b/include/drjit/extra.h
@@ -556,6 +556,18 @@ extern DRJIT_EXTRA_EXPORT void ad_reorder(uint64_t key, uint32_t num_bits,
 /// Pack a set of regular Dr.Jit variables to form a cooperative vector
 extern DRJIT_EXTRA_EXPORT uint64_t ad_coop_vec_pack(uint32_t n, const uint64_t *in);
 
+/// Differentiable wrapper around \ref jit_coop_vec_pack_matrices. The
+/// underlying primitive packs ``count`` matrices residing in a single source
+/// buffer ``in`` (with layout described by ``in_descr``) into a single
+/// destination buffer ``out`` (described by ``out_descr``); this wrapper adds
+/// forward- and reverse-mode AD on top, with the adjoint implemented via the
+/// same primitive invoked on swapped descriptor pairs. Returns a (possibly
+/// new) AD-attached index for ``out``; if neither operand carries gradient
+/// tracking the input ``out`` index is returned unchanged.
+extern DRJIT_EXTRA_EXPORT uint64_t ad_coop_vec_pack_matrices(
+    uint32_t count, uint64_t in, const MatrixDescr *in_descr,
+    uint64_t out, const MatrixDescr *out_descr);
+
 /// Unpack a cooperative vector into its components
 extern DRJIT_EXTRA_EXPORT void ad_coop_vec_unpack(uint64_t index, uint32_t n, uint64_t *out);
 

--- a/src/extra/autodiff.cpp
+++ b/src/extra/autodiff.cpp
@@ -4231,6 +4231,174 @@ Index ad_coop_vec_pack(uint32_t n, const Index *in) {
     return result.release();
 }
 
+/**
+ * \brief AD wrapper around jit_coop_vec_pack_matrices.
+ *
+ * One instance corresponds to a single ``jit_coop_vec_pack_matrices`` call:
+ * a batch of ``count`` matrices residing in one source buffer is laid out
+ * into one destination buffer. The forward- and reverse-mode AD callbacks
+ * each issue a single ``jit_coop_vec_pack_matrices`` call; the reverse-mode
+ * callback swaps the input/output descriptor pair to invert the layout.
+ *
+ * Two AD inputs are tracked:
+ *   - ``m_inputs[0]``: the source buffer.
+ *   - ``m_inputs[1]``: the prior AD state of the destination buffer, used to
+ *     chain a sequence of pack calls that write into the same destination.
+ *     Either input slot may be 0 when its variable has no AD attachment.
+ *
+ * The chain semantics are exact when successive pack calls write to
+ * *disjoint* regions of an initially-zero destination buffer — which is the
+ * invariant that ``drjit.nn.pack`` (the only caller) maintains. Under that
+ * invariant the destination's gradient at any region only originates from
+ * one pack call, and the simple passthrough/accumulate handling below
+ * matches the OVERWRITE semantics of the underlying primitive without
+ * needing an explicit mask.
+ */
+class CoopVecPackMatrices : public dr::detail::CustomOpBase {
+public:
+    CoopVecPackMatrices(uint32_t count, const MatrixDescr *in_descr,
+                        const MatrixDescr *out_descr,
+                        size_t in_size, size_t out_size)
+        : m_in_descr(in_descr, in_descr + count),
+          m_out_descr(out_descr, out_descr + count),
+          m_in_size(in_size), m_out_size(out_size) { }
+
+    ~CoopVecPackMatrices() {
+        std::lock_guard<Lock> guard(state.lock);
+        for (uint32_t index : m_output_indices)
+            ad_var_dec_ref_int(index, state[index]);
+    }
+
+    void forward() override {
+        std::lock_guard<Lock> guard(state.lock);
+        ADVariable *target = state[m_output_indices[0]];
+
+        // Pass the prior destination's gradient through unchanged.
+        if (m_inputs[1]) {
+            ADVariable *prev = state[m_inputs[1]];
+            if (prev->grad.valid())
+                target->accum(prev->grad, target->size);
+        }
+
+        // Layout-transform the source's gradient into a fresh zero scratch
+        // buffer, then accumulate it. The scratch is zero outside the
+        // out_descr regions, so this leaves the prior gradient unchanged
+        // there. Inside the out_descr regions the prior gradient is zero
+        // by the disjoint-regions invariant noted on the class, so the
+        // accumulate likewise reproduces the OVERWRITE semantics of the
+        // underlying pack.
+        if (m_inputs[0]) {
+            ADVariable *input = state[m_inputs[0]];
+            if (input->grad.valid()) {
+                uint64_t zero = 0;
+                JitVar tmp = JitVar::steal(jit_var_literal(
+                    m_backend, m_out_descr[0].dtype, &zero,
+                    m_out_size, 1));
+                jit_coop_vec_pack_matrices(
+                    (uint32_t) m_in_descr.size(), input->grad.index(),
+                    m_in_descr.data(), tmp.index(), m_out_descr.data());
+                target->accum(tmp, target->size);
+            }
+        }
+    }
+
+    void backward() override {
+        std::lock_guard<Lock> guard(state.lock);
+        ADVariable *out = state[m_output_indices[0]];
+        if (!out->grad.valid())
+            return;
+
+        // Pass the destination's gradient back to the prior state. The
+        // disjoint-regions invariant (see class comment) ensures that the
+        // contribution at this op's out_descr regions is harmless: in the
+        // chained-pack use case the prior state is consumed only by this
+        // op, so any spurious gradient at the overwritten regions has no
+        // downstream effect.
+        if (m_inputs[1]) {
+            ADVariable *prev = state[m_inputs[1]];
+            prev->accum(out->grad, prev->size);
+        }
+
+        // Inverse pack: read the destination's gradient at the out_descr
+        // regions, layout-convert back to the in_descr regions of a fresh
+        // scratch buffer, and accumulate into the source's gradient.
+        if (m_inputs[0]) {
+            ADVariable *input = state[m_inputs[0]];
+            uint64_t zero = 0;
+            JitVar tmp = JitVar::steal(jit_var_literal(
+                m_backend, m_in_descr[0].dtype, &zero,
+                m_in_size, 1));
+            jit_coop_vec_pack_matrices(
+                (uint32_t) m_out_descr.size(), out->grad.index(),
+                m_out_descr.data(), tmp.index(), m_in_descr.data());
+            input->accum(tmp, input->size);
+        }
+    }
+
+    void add_input(JitBackend backend, uint32_t index) {
+        add_index(backend, index, true);
+        m_inputs.push_back(index);
+    }
+
+    void add_output(JitBackend backend, uint32_t index) {
+        add_index(backend, index, false);
+        std::lock_guard<Lock> guard(state.lock);
+        ad_var_inc_ref_int(index, state[index]);
+    }
+
+    const char *name() const override { return "pack_matrices"; }
+
+private:
+    std::vector<MatrixDescr> m_in_descr, m_out_descr;
+    std::vector<uint32_t> m_inputs;
+    size_t m_in_size, m_out_size;
+};
+
+/**
+ * Differentiable wrapper around \ref jit_coop_vec_pack_matrices. The semantics
+ * match the underlying primitive — ``count`` matrices are packed from the
+ * ``in`` buffer (with layout described by ``in_descr``) into the ``out``
+ * buffer (described by ``out_descr``). The output buffer is mutated in place;
+ * if neither operand has AD attachment the call is a thin wrapper around the
+ * JIT primitive and the unchanged ``out`` index is returned. Otherwise a
+ * fresh AD variable is created on top of the output buffer's JIT index, and
+ * the returned combined index reflects this attachment.
+ */
+Index ad_coop_vec_pack_matrices(uint32_t count, Index in,
+                                const MatrixDescr *in_descr, Index out,
+                                const MatrixDescr *out_descr) {
+    if (count == 0)
+        return out;
+
+    JitIndex in_j  = jit_index(in),
+             out_j = jit_index(out);
+
+    jit_coop_vec_pack_matrices(count, in_j, in_descr, out_j, out_descr);
+
+    ADIndex in_a  = ad_index(in),
+            out_a = ad_index(out);
+
+    if (in_a == 0 && out_a == 0)
+        return out;
+
+    VarInfo vi = jit_set_backend(out_j);
+
+    ref<CoopVecPackMatrices> op = new CoopVecPackMatrices(
+        count, in_descr, out_descr,
+        jit_var_size(in_j), jit_var_size(out_j));
+    op->add_input(vi.backend, in_a);
+    op->add_input(vi.backend, out_a);
+
+    uint64_t ad_result = ad_var_new(out_j);
+    op->add_output(vi.backend, ad_index(ad_result));
+
+    if (ad_custom_op(op.get()))
+        return ad_result;
+
+    ad_var_dec_ref(ad_result);
+    return out;
+}
+
 class CoopVecUnpack : public dr::detail::CustomOpBase {
 public:
     ~CoopVecUnpack() {

--- a/src/python/coop_vec.cpp
+++ b/src/python/coop_vec.cpp
@@ -471,7 +471,7 @@ static nb::object repack_impl(const char *name, MatrixLayout layout,
     }
 }
 
-static std::pair<nb::object, nb::object> repack(const char *name, const char *layout_str, nb::handle arg) {
+static nb::object repack(const char *name, const char *layout_str, nb::handle arg) {
     uint32_t offset = 0;
     std::vector<RepackItem> items;
     MatrixLayout layout;
@@ -502,13 +502,16 @@ static std::pair<nb::object, nb::object> repack(const char *name, const char *la
         out.reserve(items.size());
 
         auto submit = [&] {
-            jit_coop_vec_pack_matrices(
+            uint64_t new_out = ad_coop_vec_pack_matrices(
                 (uint32_t) in.size(),
-                (uint32_t) s.index(inst_ptr(buf_cur)),
+                s.index(inst_ptr(buf_cur)),
                 in.data(),
-                (uint32_t) s.index(inst_ptr(buffer)),
+                s.index(inst_ptr(buffer)),
                 out.data()
             );
+            // Promote buffer's AD index when ad_coop_vec_pack_matrices wraps
+            // the in-place pack in a fresh AD variable.
+            s.reset_index(new_out, inst_ptr(buffer));
         };
 
         for (size_t i = 0; i < items.size(); ++i) {
@@ -539,7 +542,13 @@ static std::pair<nb::object, nb::object> repack(const char *name, const char *la
             submit();
     }
 
-    return { buffer, result };
+    // Stash the packed weights so that drjit.nn.Module can find them
+    if (!buffer.is_none() && layout != MatrixLayout::RowMajor &&
+        !result.type().is(view_type) &&
+        get_drjit_struct(result.type()).is_valid())
+        nb::setattr(result, "_packed_buffer", buffer);
+
+    return result;
 }
 
 static CoopVec coopvec_abs_workaround(nb::handle_t<CoopVec> &v) {
@@ -677,38 +686,28 @@ void export_coop_vec(nb::module_ &m) {
 
     nn.def("pack", [](nb::handle arg, const char *layout) { return repack("pack", layout, arg); },
            nb::arg(), "layout"_a = "inference",
-           nb::sig("def pack(arg: MatrixView | drjit.AnyArray, *, layout: typing.Literal['inference', 'training'] = 'inference') -> typing.Tuple[drjit.ArrayBase, MatrixView]"),
+           nb::sig("def pack(arg: MatrixView | drjit.AnyArray, *, layout: typing.Literal['inference', 'training'] = 'inference') -> MatrixView"),
            doc_nn_pack);
 
     nn.def("pack",
            [](nb::args args, const char *layout) {
-               auto temp = repack("pack", layout, args);
-               nb::list l;
-               l.append(temp.first);
-               l.extend(temp.second);
-               return nb::tuple(l);
+               return nb::tuple(repack("pack", layout, args));
            },
            "args"_a, "layout"_a = "inference",
            nb::sig("def pack(*args: PyTree, layout: typing.Literal['inference', "
-                   "'training'] = 'inference') -> typing.Tuple[drjit.ArrayBase, "
-                   "typing.Unpack[typing.Tuple[PyTree, ...]]]"));
+                   "'training'] = 'inference') -> typing.Tuple[PyTree, ...]"));
 
     nn.def("unpack", [](nb::handle arg) {
         return repack("unpack", nullptr, arg); },
-           nb::sig("def unpack(arg: MatrixView | drjit.AnyArray, /) -> typing.Tuple[drjit.ArrayBase, MatrixView]"),
+           nb::sig("def unpack(arg: MatrixView | drjit.AnyArray, /) -> MatrixView"),
            doc_nn_unpack);
 
     nn.def("unpack",
            [](nb::args args) {
-               auto temp = repack("unpack", nullptr, args);
-               nb::list l;
-               l.append(temp.first);
-               l.extend(temp.second);
-               return nb::tuple(l);
+               return nb::tuple(repack("unpack", nullptr, args));
            },
            "args"_a,
-           nb::sig("def unpack(*args: PyTree) -> typing.Tuple[drjit.ArrayBase, "
-                   "typing.Unpack[typing.Tuple[PyTree, ...]]]"));
+           nb::sig("def unpack(*args: PyTree) -> typing.Tuple[PyTree, ...]"));
 
     nn.def("matvec", &matvec, "A"_a.noconvert(), "x"_a.noconvert(),
            "b"_a.noconvert() = nb::none(), "transpose"_a = false,

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -9032,7 +9032,15 @@
 
 .. topic:: nn_pack
 
-   A training-optimal layout must be used used if the program *backpropagates*
+   Re-pack a set of matrices and bias vectors into a single contiguous buffer
+   with an inference- or training-optimal layout for use with
+   :py:func:`drjit.nn.matvec`.
+
+   When the argument is an :py:class:`nn.Module <drjit.nn.Module>`, the
+   function returns ``(buffer, packed_module)``; see :py:class:`nn.Module
+   <drjit.nn.Module>` for the training-loop pattern.
+
+   A training-optimal layout must be used if the program *backpropagates*
    (as in :py:func:`dr.backward*() <drjit.backward>`) gradients through
    matrix-vector products. Inference (primal evaluation) and forward derivative
    propagation (as in :py:func:`dr.forward*() <drjit.forward>`) does not

--- a/tests/test_coop_vec.py
+++ b/tests/test_coop_vec.py
@@ -96,12 +96,12 @@ def test04_pack_unpack(t, sub_slice):
     assert Xv2.buffer is X.array
 
     for layout in ('inference', 'training'):
-        _, *Pa = nn.pack(
+        Pa = nn.pack(
             Xv1, Xv2,
             layout=layout
         )
 
-        _, X1a, X2a = nn.unpack(*Pa)
+        X1a, X2a = nn.unpack(*Pa)
         assert dr.all(m.TensorXf16(X1a) == X1[:, 0:32], axis=None)
         assert dr.all(m.TensorXf16(X2a) == X2[:, 0:32], axis=None)
 
@@ -139,10 +139,10 @@ def test05_matvec(t, shape, transpose, bias, pack):
 
     if pack:
         if bias:
-            _, A, b = nn.pack(A, b)
+            A, b = nn.pack(A, b)
             assert A.buffer is b.buffer
         else:
-            _, A = nn.pack(A)
+            A = nn.pack(A)
     else:
         A = nn.view(A)
         if bias:
@@ -349,10 +349,10 @@ def test14_matvec_fwd(t, transpose, has_A_grad, has_x_grad, has_b_grad, layout):
     # Set up 'A' matrix
     A      = [[4, 2], [5, 1]]
     A_grad = [[2, 1], [1, -1]]
-    _, A_v = nn.pack(Tensor(A), layout=layout)
+    A_v = nn.pack(Tensor(A), layout=layout)
     A_ref = Matrix2f(A)
     if has_A_grad:
-        _, A_grad_v = nn.pack(Tensor(A_grad))
+        A_grad_v = nn.pack(Tensor(A_grad))
         assert not dr.grad_enabled(A_v)
         dr.enable_grad(A_v)
         assert dr.grad_enabled(A_v)
@@ -374,12 +374,12 @@ def test14_matvec_fwd(t, transpose, has_A_grad, has_x_grad, has_b_grad, layout):
     if has_b_grad is not None:
         b1, b2 = Float(-1), Float(1)
         b_ref = Array2f(b1, b2)
-        _, b_v = nn.pack(Tensor([-1, 1]))
+        b_v = nn.pack(Tensor([-1, 1]))
 
         if has_b_grad is True:
             dr.enable_grad(b_ref)
             b_ref.grad = [1, -1]
-            _, b_grad_v = nn.pack(Tensor([1, -1]))
+            b_grad_v = nn.pack(Tensor([1, -1]))
             dr.enable_grad(b_v.buffer)
             b_v.buffer.grad = b_grad_v.buffer
 
@@ -410,7 +410,7 @@ def test15_matvec_in_vcall(t, transpose):
     rng = dr.rng()
     A = rng.normal(t, (size, size))
     b = rng.normal(t, size)
-    _, A, b = nn.pack(A, b)
+    A, b = nn.pack(A, b)
 
     def mult_it():
         x = nn.CoopVec(
@@ -449,14 +449,16 @@ def test16_matvec_bwd(t, in_vcall, grad_lit, separate_buffers):
     A = t([[1, 3], [-2, 4], [3, -2]])
     b = t([0, 0, 0])
     if separate_buffers:
-        buffer, Av= nn.pack(A, layout='training')
-        buffer_bias, bv = nn.pack(b, layout='training')
+        Av = nn.pack(A, layout='training')
+        bv = nn.pack(b, layout='training')
     else:
-        buffer, Av, bv = nn.pack(A, b, layout='training')
+        Av, bv = nn.pack(A, b, layout='training')
+    buffer = Av.buffer
     x = m.Array2f16(2, 4)
     dr.enable_grad(x, buffer)
 
     if separate_buffers:
+        buffer_bias = bv.buffer
         dr.enable_grad(x, buffer_bias)
     dr.enable_grad(x, buffer)
 
@@ -488,8 +490,8 @@ def test16_matvec_bwd(t, in_vcall, grad_lit, separate_buffers):
     assert dr.all(grad_x_ref == grad_x)
 
     dr.schedule(grad_x)
-    _, grad_A = nn.unpack(Av.grad)
-    _, grad_b = nn.unpack(bv.grad)
+    grad_A = nn.unpack(Av.grad)
+    grad_b = nn.unpack(bv.grad)
 
     grad_A = t(grad_A)
     grad_b = t(grad_b)[:, 0]
@@ -583,12 +585,13 @@ def test20_matvec_in_loop(t, mode):
     A = dr.ones(TensorXf16, shape=(2, 2))
     b = dr.zeros(Float16, shape=(2))
 
-    _, A_view, b_view = nn.pack(A, b, layout='inference')
+    A_view, b_view = nn.pack(A, b, layout='inference')
+    buffer = A_view.buffer
 
     cnt = UInt32(0)
     res = Float32(0)
 
-    while dr.hint(cnt < 3, mode=mode, exclude=[_]):
+    while dr.hint(cnt < 3, mode=mode, exclude=[buffer]):
         x = nn.CoopVec(Float16([0.5]), Float16([0.5]))
         a, _ = nn.matvec(A_view, x, b_view)
         res += Float32(a)
@@ -614,8 +617,8 @@ def test21_optimize_in_loop_bwd(t, mode):
     A = dr.ones(TensorXf16, shape=(2, 2))
     b = dr.zeros(Float16, shape=(2))
 
-    buf, A_view, b_view = nn.pack(A, b, layout='training')
-    dr.enable_grad(buf)
+    A_view, b_view = nn.pack(A, b, layout='training')
+    dr.enable_grad(A_view.buffer)
 
     cnt = dr.zeros(UInt32, 2)
     res = dr.zeros(Float32, 2)
@@ -628,7 +631,7 @@ def test21_optimize_in_loop_bwd(t, mode):
 
     dr.backward(res)
 
-    _, A_view, b_view = nn.unpack(A_view.grad, b_view.grad)
+    A_view, b_view = nn.unpack(A_view.grad, b_view.grad)
     A = TensorXf16(A_view)
     b = TensorXf16(b_view)
     assert dr.all(A == TensorXf16([[3, 3], [0, 0]]))
@@ -654,8 +657,8 @@ def test22_optimize_in_loop_bwd_v2(t, mode):
     A = dr.ones(TensorXf16, shape=(2, 2))
     b = dr.zeros(Float16, shape=(2))
 
-    buf, A_view, b_view = nn.pack(A, b, layout='training')
-    dr.enable_grad(buf)
+    A_view, b_view = nn.pack(A, b, layout='training')
+    dr.enable_grad(A_view.buffer)
 
     cnt = dr.zeros(UInt32, 2)
     res = dr.zeros(Float32, 2)
@@ -667,7 +670,7 @@ def test22_optimize_in_loop_bwd_v2(t, mode):
         dr.backward(res)
         cnt += 1
 
-    _, A_view, b_view = nn.unpack(A_view.grad, b_view.grad)
+    A_view, b_view = nn.unpack(A_view.grad, b_view.grad)
     A = TensorXf16(A_view)
     b = TensorXf16(b_view)
     assert dr.all(A == TensorXf16([[3, 3], [0, 0]]))
@@ -698,4 +701,87 @@ def test25_suspend_grad(t):
     dr.enable_grad(y)
     with dr.suspend_grad():
         z = nn.CoopVec(x, y)
+
+
+@pytest.test_arrays('jit,shape=(*),float16,diff')
+def test26_pack_matrices_bwd(t):
+    skip_if_coopvec_not_supported(t)
+
+    # Reverse-mode AD through nn.pack: gradient on the packed buffer must
+    # flow back to the row-major source matrix via the inverse layout. The
+    # backward matvec primitive (jit_coop_vec_outer_product_accum) requires a
+    # training-optimal layout on CUDA, so the inference layout is not exercised
+    # here.
+    m = sys.modules[t.__module__]
+    TensorXf16 = m.TensorXf16
+    Array2f16 = m.Array2f16
+    Array3f16 = m.Array3f16
+
+    A_data = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+    A = TensorXf16(A_data)
+    dr.enable_grad(A)
+
+    A_view = nn.pack(A, layout='training')
+    assert dr.grad_enabled(A_view.buffer)
+
+    x = Array2f16(2.0, 3.0)
+    y = Array3f16(nn.matvec(A_view, nn.CoopVec(x)))
+    dr.backward(dr.sum(y))
+
+    # dL/dA[i, j] = x[j] for L = sum_i (A @ x)_i.
+    A_grad = TensorXf16(A.grad)
+    assert dr.all(A_grad == TensorXf16([[2, 3], [2, 3], [2, 3]]))
+
+
+@pytest.mark.parametrize('layout', ['training', 'inference'])
+@pytest.test_arrays('jit,shape=(*),float16,diff')
+def test27_pack_matrices_fwd(t, layout):
+    skip_if_coopvec_not_supported(t)
+    if dr.backend_v(t) == dr.JitBackend.LLVM and layout == 'training':
+        pytest.skip("Layout not used in LLVM backend")
+
+    # Forward-mode AD through nn.pack.
+    m = sys.modules[t.__module__]
+    TensorXf16 = m.TensorXf16
+    Array2f16 = m.Array2f16
+    Array3f16 = m.Array3f16
+
+    A = TensorXf16([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    dr.enable_grad(A)
+    dr.set_grad(A, TensorXf16([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]))
+
+    A_view = nn.pack(A, layout=layout)
+    x = Array2f16(2.0, 3.0)
+    y = Array3f16(nn.matvec(A_view, nn.CoopVec(x)))
+    dr.forward_to(y)
+
+    # y.grad[i] = sum_j (dA/dt)[i, j] * x[j].
+    assert dr.all(y.grad == Array3f16(2, 3, 5))
+
+
+@pytest.test_arrays('jit,shape=(*),float16,diff')
+def test28_pack_matrices_mixed(t):
+    # Mixed AD-enabled / non-AD inputs to nn.pack: only the source carrying
+    # gradient receives a backward contribution.
+    skip_if_coopvec_not_supported(t)
+
+    m = sys.modules[t.__module__]
+    TensorXf16 = m.TensorXf16
+    Array2f16 = m.Array2f16
+
+    A = TensorXf16([[1.0, 2.0], [3.0, 4.0]])
+    B = TensorXf16([[5.0, 6.0]])
+    dr.enable_grad(A)
+
+    A_view, B_view = nn.pack(A, B, layout='training')
+    assert dr.grad_enabled(A_view.buffer)
+    assert not dr.grad_enabled(B)
+
+    x = Array2f16(2.0, 3.0)
+    y_a = Array2f16(nn.matvec(A_view, nn.CoopVec(x)))
+    y_b_v = nn.matvec(B_view, nn.CoopVec(x))
+    loss = dr.sum(y_a) + dr.sum(t(*y_b_v))
+    dr.backward(loss)
+
+    assert dr.all(TensorXf16(A.grad) == TensorXf16([[2, 3], [2, 3]]))
 

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -3608,7 +3608,7 @@ def test96_coop_vec(t, auto_opaque, layout):
     rng = dr.rng(seed=0)
     net = net.alloc(TensorXf16, size=2, rng=rng)
 
-    weights, net = nn.pack(net, layout=layout)
+    net = nn.pack(net, layout=layout)
 
     rng = dr.rng()
     for i in range(3):
@@ -3653,7 +3653,8 @@ def test97_coop_vec_bwd(t, auto_opaque):
 
     net = net.alloc(TensorXf16, 2)
 
-    weights, net = nn.pack(net, layout="training")
+    net = nn.pack(net, layout="training")
+    weights = net['weights']
 
     rng = dr.rng()
     x = rng.random(ArrayXf, (2, 2))

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1,0 +1,382 @@
+import drjit as dr
+import drjit.nn as nn
+import pytest
+import sys
+
+
+def skip_if_coopvec_not_supported(t):
+    backend = dr.backend_v(t)
+    if backend == dr.JitBackend.CUDA:
+        if dr.detail.cuda_version() < (12, 8):
+            pytest.skip("CUDA driver does not support cooperative vectors (Driver R570) or later is required")
+    elif backend == dr.JitBackend.LLVM:
+        if dr.detail.llvm_version() < (17, 0):
+            pytest.skip("LLVM does not support cooperative vectors, 17.0 or later is required")
+
+
+@pytest.test_arrays('jit,shape=(*),float16,diff')
+def test01_mapping(t):
+    """MutableMapping surface: iteration, indexed reads/writes, update, bad keys, delitem."""
+    mod = sys.modules[t.__module__]
+    TensorXf16 = mod.TensorXf16
+
+    net = nn.Sequential(
+        nn.Linear(2, 4, bias=True),
+        nn.ReLU(),
+        nn.Linear(-1, 3, bias=False),
+    ).alloc(TensorXf16, 2)
+
+    expected = ['layers.0.weights', 'layers.0.bias', 'layers.2.weights']
+    assert list(net.keys()) == expected
+    assert list(iter(net)) == expected
+    assert len(net) == len(expected)
+    assert 'layers.0.weights' in net
+    assert 'bogus' not in net
+
+    items = dict(net.items())
+    assert set(items) == set(expected)
+    values = list(net.values())
+    assert len(values) == 3 and all(isinstance(v, TensorXf16) for v in values)
+    for k in expected:
+        assert items[k] is net[k]
+
+    new_w = dr.full(TensorXf16, 3.0, (4, 2))
+    net['layers.0.weights'] = new_w
+    assert net.layers[0].weights is new_w
+    assert dr.all(net['layers.0.weights'] == TensorXf16(3), axis=None)
+
+    net.update({
+        'layers.0.bias': dr.full(TensorXf16, 0.5, 4),
+        'layers.2.weights': dr.full(TensorXf16, -1.0, (3, 4)),
+    })
+    assert dr.all(net['layers.0.bias'] == TensorXf16(0.5), axis=None)
+    assert dr.all(net['layers.2.weights'] == TensorXf16(-1.0), axis=None)
+
+    with pytest.raises(KeyError):
+        net['bogus']
+    with pytest.raises(KeyError):
+        net['bogus'] = dr.zeros(TensorXf16, (4, 2))
+    with pytest.raises(TypeError):
+        del net['layers.0.weights']
+
+
+@pytest.test_arrays('jit,shape=(*),float16,diff')
+def test02_setitem_dtype_cast(t):
+    """Setting an fp32 value into an fp16 slot casts automatically."""
+    mod = sys.modules[t.__module__]
+    TensorXf = mod.TensorXf
+    TensorXf16 = mod.TensorXf16
+
+    net = nn.Sequential(nn.Linear(2, 4, bias=True)).alloc(TensorXf16, 2)
+
+    net['layers.0.weights'] = dr.full(TensorXf, 2.5, (4, 2))
+    got = net['layers.0.weights']
+    assert isinstance(got, TensorXf16)
+    assert dr.all(got == TensorXf16(2.5), axis=None)
+
+
+@pytest.test_arrays('jit,shape=(*),float16,diff')
+def test03_prefix(t):
+    """A prefix passed to Sequential namespaces every mapping key."""
+    mod = sys.modules[t.__module__]
+    TensorXf16 = mod.TensorXf16
+
+    net = nn.Sequential(nn.Linear(2, 4), prefix='mlp').alloc(TensorXf16, 2)
+    assert net.prefix == 'mlp'
+    assert set(net.keys()) == {'mlp.layers.0.weights', 'mlp.layers.0.bias'}
+    assert 'mlp.layers.0.weights' in net
+
+
+@pytest.test_arrays('jit,shape=(*),float16,diff')
+def test04_linear_errors(t):
+    """Linear rejects unallocated calls and CoopVec calls on unpacked weights."""
+    skip_if_coopvec_not_supported(t)
+    mod = sys.modules[t.__module__]
+    TensorXf16 = mod.TensorXf16
+
+    x = nn.CoopVec(dr.full(t, 1.0, 8), dr.full(t, 2.0, 8))
+
+    uninit_msg = (
+        "drjit.nn.Linear: uninitialized network. Call "
+        "'net = net.alloc(<Tensor type>)' to initialize the weight "
+        "storage first."
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        nn.Linear(2, 4)(x)
+    assert str(excinfo.value) == uninit_msg
+
+    unpacked_msg = (
+        "drjit.nn.Linear: cooperative-vector evaluation requires "
+        "packed weights. Call 'drjit.nn.pack(net)' to transform "
+        "the network into a cooperative-vector layout."
+    )
+    net = nn.Sequential(nn.Linear(2, 4)).alloc(TensorXf16, 2)
+    with pytest.raises(RuntimeError) as excinfo:
+        net(x)
+    assert str(excinfo.value) == unpacked_msg
+
+
+@pytest.test_arrays('jit,shape=(*),float16,diff')
+def test05_opt_roundtrip(t):
+    """opt.update(net) then net.update(opt) preserves dtype + shapes."""
+    from drjit.opt import Adam
+    mod = sys.modules[t.__module__]
+    TensorXf16 = mod.TensorXf16
+
+    net = nn.Sequential(
+        nn.Linear(2, 4, bias=True),
+        nn.Linear(-1, 3, bias=False),
+    ).alloc(TensorXf16, 2)
+
+    opt = Adam(lr=1e-3)
+    opt.update(net)
+
+    for k in list(opt.keys()):
+        opt[k] = dr.full(type(opt[k]), 0.125, opt[k].shape)
+
+    net.update(opt)
+    for k, v in net.items():
+        assert isinstance(v, TensorXf16)
+        assert dr.all(v == TensorXf16(0.125), axis=None)
+
+
+# ---------------------------------------------------------------------------
+# Consistency: tensor mode vs cooperative-vector mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.test_arrays('jit,shape=(*),float16,diff')
+def test06_tensor_vs_coopvec_parity(t):
+    """Forward + input-gradient parity on a multi-layer Sequential."""
+    skip_if_coopvec_not_supported(t)
+    mod = sys.modules[t.__module__]
+    TensorXf16 = mod.TensorXf16
+    ArrayXf16 = mod.ArrayXf16
+    Float16 = t
+
+    tensor_net = nn.Sequential(
+        nn.Linear(2, 4, bias=True),
+        nn.ReLU(),
+        nn.Linear(-1, 3, bias=True),
+    ).alloc(TensorXf16, 2, rng=dr.rng(seed=0xc0ffee))
+    coop_net = nn.pack(dr.copy(tensor_net), layout='training')
+
+    C, N = 2, 5
+    data = [[0.2 + 0.05 * i + 0.03 * j for j in range(N)] for i in range(C)]
+
+    x_tensor = TensorXf16(data)
+    dr.enable_grad(x_tensor)
+    y_tensor = tensor_net(x_tensor)
+
+    x_rows = [Float16(data[i]) for i in range(C)]
+    dr.enable_grad(x_rows)
+    y_coop = ArrayXf16(coop_net(nn.CoopVec(*x_rows)))
+
+    assert y_tensor.shape[0] == len(y_coop)
+    for i in range(y_tensor.shape[0]):
+        assert dr.allclose(Float16(y_tensor[i]), y_coop[i], atol=2e-2)
+
+    dr.backward(dr.sum(y_tensor.array))
+    dr.backward(dr.sum(dr.sum(y_coop)))
+    for i, r in enumerate(x_rows):
+        assert dr.allclose(Float16(x_tensor.grad[i]), r.grad, atol=2e-2)
+
+
+# Factory / has-weights pairs for test07. Layers with trainable weights
+# must go through ``nn.pack`` before accepting CoopVec inputs; stateless
+# activations use the same module instance in both modes.
+_LAYER_CASES = [
+    pytest.param(lambda: nn.Linear(-1, 4, bias=True), True, id='linear'),
+    pytest.param(lambda: nn.Linear(-1, 4, bias=False), True, id='linear_no_bias'),
+    pytest.param(lambda: nn.ReLU(), False, id='relu'),
+    pytest.param(lambda: nn.LeakyReLU(negative_slope=0.1), False, id='leaky_relu'),
+    pytest.param(lambda: nn.Exp2(), False, id='exp2'),
+    pytest.param(lambda: nn.Exp(), False, id='exp'),
+    pytest.param(lambda: nn.Tanh(), False, id='tanh'),
+    pytest.param(lambda: nn.ScaleAdd(scale=2.0, offset=0.5), False, id='scale_add'),
+    pytest.param(lambda: nn.TriEncode(octaves=2, shift=0.3), False, id='tri_encode'),
+    pytest.param(lambda: nn.SinEncode(octaves=2, shift=0.3), False, id='sin_encode'),
+]
+
+
+@pytest.mark.parametrize('layer_ctor,has_weights', _LAYER_CASES)
+@pytest.test_arrays('jit,shape=(*),float16,diff')
+def test07_layer_mode_consistency(t, layer_ctor, has_weights):
+    """Each nn layer must produce matching outputs and input gradients
+    in tensor mode and in cooperative-vector mode."""
+    skip_if_coopvec_not_supported(t)
+    mod = sys.modules[t.__module__]
+    TensorXf16 = mod.TensorXf16
+    ArrayXf16 = mod.ArrayXf16
+    Float16 = t
+
+    C, N = 3, 4
+
+    tensor_net = nn.Sequential(layer_ctor()).alloc(
+        TensorXf16, C, rng=dr.rng(seed=0xc0ffee)
+    )
+    if has_weights:
+        coop_net = nn.pack(dr.copy(tensor_net), layout='training')
+    else:
+        coop_net = tensor_net
+
+    # Inputs stay inside [0, 1) (period of the encoders) while still
+    # varying enough to exercise non-trivial gradients for activations.
+    data = [[0.1 + 0.15 * i + 0.07 * j for j in range(N)] for i in range(C)]
+
+    x_tensor = TensorXf16(data)
+    dr.enable_grad(x_tensor)
+    y_tensor = tensor_net(x_tensor)
+
+    x_rows = [Float16(data[i]) for i in range(C)]
+    dr.enable_grad(x_rows)
+    y_coop = ArrayXf16(coop_net(nn.CoopVec(*x_rows)))
+
+    assert y_tensor.shape[0] == len(y_coop)
+    for i in range(y_tensor.shape[0]):
+        assert dr.allclose(Float16(y_tensor[i]), y_coop[i], atol=2e-2)
+
+    dr.backward(dr.sum(y_tensor.array))
+    dr.backward(dr.sum(dr.sum(y_coop)))
+    for i, r in enumerate(x_rows):
+        assert dr.allclose(Float16(x_tensor.grad[i]), r.grad, atol=2e-2)
+
+
+@pytest.test_arrays('jit,shape=(*),float32,diff')
+@pytest.mark.parametrize("octaves", [1, 4])
+@pytest.mark.parametrize("shift", [0.0, 0.3])
+@pytest.mark.parametrize("encoding_cls", [nn.TriEncode, nn.SinEncode])
+def test08_encode_mode_parity(t, octaves, shift, encoding_cls):
+    """Encoder tensor-mode output must match the per-channel CoopVec output
+    entry-by-entry (in fp32, for both encodings, with/without shift)."""
+    skip_if_coopvec_not_supported(t)
+    mod = sys.modules[t.__module__]
+    TensorXf = mod.TensorXf
+    Float32 = t
+
+    enc = encoding_cls(octaves=octaves, shift=shift).alloc(TensorXf, 3)
+
+    C, N = 3, 6
+    x_tensor = dr.full(TensorXf, 0.37, (C, N))
+    y_tensor = enc(x_tensor)
+    assert y_tensor.shape == (2 * octaves * C, N)
+
+    cv = nn.CoopVec(*(dr.full(Float32, 0.37, N) for _ in range(C)))
+    y_cv = list(enc(cv))
+    assert len(y_cv) == 2 * octaves * C
+
+    tol = 1e-5 if encoding_cls is nn.SinEncode else 1e-6
+    for k in range(2 * octaves * C):
+        assert dr.allclose(Float32(y_tensor[k]), y_cv[k], atol=tol)
+
+
+@pytest.test_arrays('jit,shape=(*),float16,diff')
+def test09_muon_cross_mode_consistency(t):
+    """Muon drives the same loss trajectory in tensor mode and in coopvec mode.
+
+    Both runs share the alloc seed and input data, so the initial weights
+    and targets match. The per-step Muon update is computed in fp32;
+    coopvec mode evaluates through hardware fp16 matvec whereas tensor
+    mode uses row-major fp16 matmul. They should agree to within a
+    generous fp16 tolerance.
+    """
+    skip_if_coopvec_not_supported(t)
+    from drjit.opt import Muon
+    mod = sys.modules[t.__module__]
+    TensorXf16 = mod.TensorXf16
+    Float16 = t
+    Float32 = mod.Float32
+
+    n_iter = 12
+
+    init_net = nn.Sequential(
+        nn.Linear(4, 32, bias=False),
+        nn.Tanh(),
+        nn.Linear(-1, 4, bias=False),
+    ).alloc(TensorXf16, 4)
+    rng = dr.rng()
+    x = rng.random(TensorXf16, (4, 16))
+    y_ref = rng.random(TensorXf16, (4, 16))
+
+    def run(use_coopvec):
+        net = dr.copy(init_net)
+        muon = Muon(lr=0.05, momentum=0.9, ns_steps=5)
+        muon.update(net)
+
+        losses = []
+        for _ in range(n_iter):
+            net.update(muon)
+            if use_coopvec:
+                packed_net = nn.pack(net, layout='training')
+                cv_in = nn.CoopVec(*[Float16(x[i]) for i in range(4)])
+                y_cv = list(packed_net(cv_in))
+                loss = Float32(0)
+                for i in range(4):
+                    diff = y_cv[i] - Float16(y_ref[i])
+                    loss += dr.sum(Float32(diff * diff))
+            else:
+                diff = (net(x) - y_ref).array
+                loss = Float32(dr.sum(Float32(diff * diff)))
+            dr.backward(loss)
+            muon.step()
+            losses.append(float(loss[0]))
+        return losses
+
+    losses_tensor  = run(use_coopvec=False)
+    losses_coopvec = run(use_coopvec=True)
+
+    for lt, lc in zip(losses_tensor, losses_coopvec):
+        assert abs(lt - lc) <= 0.01 * abs(lt), \
+            f"trajectories diverge: tensor={lt:.4f} coopvec={lc:.4f}"
+
+
+# ---------------------------------------------------------------------------
+# Closed-form formula checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.test_arrays('jit,shape=(*),float32,diff')
+def test10_triencode_formula(t):
+    """TriEncode output matches the closed-form formula exactly."""
+    skip_if_coopvec_not_supported(t)
+    mod = sys.modules[t.__module__]
+    TensorXf = mod.TensorXf
+
+    octaves, shift = 3, 0.15
+    enc = nn.TriEncode(octaves=octaves, shift=shift).alloc(TensorXf, 1)
+
+    x = TensorXf([[0.11, 0.22, 0.33]])
+    out = enc(x)
+
+    def sin_tri(a):
+        s = a - 0.25
+        return 1 - 4 * abs(s - round(s))
+    def cos_tri(a):
+        return 1 - 4 * abs(a - round(a))
+
+    for i in range(octaves):
+        for n, xv in enumerate([0.11, 0.22, 0.33]):
+            a = (2 ** i) * xv + i * shift
+            assert abs(float(out[2*i + 0, n].array[0]) - sin_tri(a)) < 1e-6
+            assert abs(float(out[2*i + 1, n].array[0]) - cos_tri(a)) < 1e-6
+
+
+@pytest.test_arrays('jit,shape=(*),float32,diff')
+def test11_sinencode_formula(t):
+    """SinEncode output matches the closed-form formula (shift in periods)."""
+    skip_if_coopvec_not_supported(t)
+    mod = sys.modules[t.__module__]
+    TensorXf = mod.TensorXf
+
+    octaves, shift = 3, 0.15
+    enc = nn.SinEncode(octaves=octaves, shift=shift).alloc(TensorXf, 1)
+
+    x = TensorXf([[0.11, 0.22]])
+    out = enc(x)
+
+    import math
+    for i in range(octaves):
+        for n, xv in enumerate([0.11, 0.22]):
+            angle = 2 * math.pi * ((2 ** i) * xv + i * shift)
+            assert abs(float(out[2*i + 0, n].array[0]) - math.sin(angle)) < 1e-5
+            assert abs(float(out[2*i + 1, n].array[0]) - math.cos(angle)) < 1e-5

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -13,7 +13,7 @@ def test01_basic(t):
     with pytest.raises(KeyError, match="nonexistent"):
         opt["nonexistent"]
 
-    with pytest.raises(TypeError, match='parameter "x" is not differentiable'):
+    with pytest.raises(TypeError, match='cannot register parameter "x" of type "int"'):
         opt["x"] = 1  # type: ignore
 
     with pytest.raises(RuntimeError, match='parameter "x" is empty'):


### PR DESCRIPTION
Besides cooperative vectors, the ``drjit.nn`` API now also accepts regular tensors as inputs through the same ``__call__`` interface. Cooperative vectors better fuse with surrounding computation, while tensor evaluation is convenient for batched evaluation of much larger networks. The two modes are described in detail in the neural network documentation.

Every ``nn.Module`` is now also a ``MutableMapping`` keyed by the full path to each parameter (e.g. ``'layers.0.weights'``), and the optimizer integration is driven through this interface. ``opt.update(net)`` pulls every parameter into the optimizer initially and casts to the correct precision, and ``net.update(opt)`` pushes the updated state back into the network at the start of each step.

In Dr.Jit 1.1.0, users had to manually cast the packed buffer to ``Float32`` for the optimizer and write it back to ``Float16`` each iteration:

```python
weights, net = nn.pack(net, layout='training')
opt = Adam(lr=1e-3, params={'weights': Float32(weights)})

for i in range(n):
    weights[:] = Float16(opt['weights'])
    ...
```

This is no longer required:

```python
net = nn.pack(net, layout='training')
opt = Adam(lr=1e-3)
opt.update(net)

for i in range(n):
    net.update(opt)
    ...
```

``nn.pack()`` is now differentiable. This unlocks matrix-level optimizers such as ``Muon`` on cooperative-vector networks via an in-loop ``nn.pack`` pattern. See the neural network documentation for details.

Fixed a bug in ``nn.SinEncode`` where the per-octave phase offset did not match the documented formula. Code using ``shift=0`` is unaffected.