### PR TITLE
Add general-purpose reverse-mode AD for symbolic loops (+tests)

### DIFF
--- a/docs/autodiff.rst
+++ b/docs/autodiff.rst
@@ -551,23 +551,45 @@ Please review the following AD-related functions for more details:
   <resume_grad>`, :py:func:`dr.isolate_grad() <isolate_grad>`.
 - Interfacing with other AD frameworks: :py:func:`dr.wrap() <wrap>`.
 
+.. _diff_loops:
+
 Differentiating loops
 ---------------------
 
-(Most of this section still needs to be written)
+Dr.Jit supports two reverse-mode differentiation strategies for
+:py:func:`dr.while_loop() <while_loop>`, selected via the
+``max_iterations`` hint. The two strategies have very different
+computational and memory costs, so it is worth understanding which one
+applies to a given loop.
+
+- **Sum loops** (``max_iterations=-1``). When the differentiable outputs
+  are accumulated sums of per-iteration contributions, the adjoint
+  collapses into a single loop pass with no trajectory storage.
+
+- **General loops** (``max_iterations=N`` with ``N > 0``). For any
+  other loop, Dr.Jit records the loop trajectory during a forward pass
+  and replays it in reverse. The hint provides an upper bound on the
+  iteration count so that trajectory buffers can be pre-allocated.
+
+Forward-mode differentiation of loops requires no hint, since
+derivatives propagate alongside primal values in a single pass.
+
+Reverse-mode differentiation of a loop always requires an explicit
+``max_iterations`` hint (either ``-1`` or a positive integer); omitting
+it raises an error. Dr.Jit does not pick a default, since the two
+strategies differ substantially in cost and correctness domain.
 
 
-Simple loops
-^^^^^^^^^^^^
+Sum loops
+^^^^^^^^^
 
-Dr.Jit provides a specialized reverse-mode differentiation strategy for certain
-types of loops that is more efficient than the default, in particular to avoid
-potentially significant storage overheads. It can be used to handle simple
-summation loops such as
+Sum loops admit a specialized reverse-mode strategy that is dramatically
+more efficient than the general path below, both in compute and in
+memory. It can be used to handle simple summation loops such as
 
 .. code-block:: python
 
-   from drjit.auto.ad import Float, Int
+   from drjit.auto.ad import Float, UInt
 
    @dr.syntax
    def loop(x: Float, n: int):
@@ -646,4 +668,81 @@ wrap the loop condition into a :py:func:`dr.hint(..., max_iterations=-1)
            i += 1
 
        return y
+
+
+General loops
+^^^^^^^^^^^^^
+
+Many loops are not reducible to a plain sum. For example, the snippet
+below repeatedly squares its input, so that after :math:`n` iterations
+:math:`y = x^{2^n}`:
+
+.. code-block:: python
+
+   @dr.syntax
+   def iterated_square(x: Float, n: int):
+       y, i = Float(x), UInt(0)
+       while dr.hint(i < n, max_iterations=n):
+           y = y * y
+           i += 1
+       return y
+
+Here, the per-iteration contribution to :math:`\partial y/\partial x`
+depends on the running value of :math:`y`, so the sum-loop optimization
+does not apply.
+
+For loops of this kind, pass a **positive integer** ``max_iterations=N``
+that bounds the iteration count. Dr.Jit then differentiates the loop in
+two symbolic passes:
+
+1. A forward pass runs the loop and writes the pre-iteration value of
+   every loop state variable into per-thread arrays of length
+   :math:`N`.
+2. A reverse pass decrements an iteration counter from the final value
+   back to zero. At each step, it reconstructs the per-iteration inputs
+   from the recorded trajectory, wraps the differentiable slots in
+   fresh AD variables, re-runs the body, and lets reverse-mode AD walk
+   the resulting one-iteration subgraph to accumulate gradients.
+
+This strategy imposes no structural constraints on the loop body: state
+variables may couple in arbitrary ways, iteration counts may vary
+per-lane, and gradients to implicit inputs (e.g., values read via
+:py:func:`dr.gather() <gather>` from an external grad-enabled buffer)
+flow naturally through the replayed subgraph. Nested loops are also
+supported; both levels simply need their own ``max_iterations`` hint.
+
+The general path is correct for sum loops as well, but it is strictly
+more expensive than ``max_iterations=-1``, which should therefore be
+preferred whenever it applies.
+
+**Choosing the bound.** The hint must be an upper bound on the
+iteration count of every lane (equality is fine). Trajectory storage
+scales linearly with ``max_iterations``, allocating one entry per
+thread per *non-invariant* loop state variable (including
+non-differentiable ones such as the iteration counter), so the bound
+should be set as tight as the application allows. If the bound is
+exceeded at runtime, the trajectory is silently truncated in release
+builds and the resulting gradients are incorrect. Enable
+:py:attr:`dr.JitFlag.Debug <drjit.JitFlag>` to surface a warning of
+the form
+
+.. code-block:: text
+
+   drjit.Local.write(): out-of-bounds write to position 3 in an array of size 3.
+
+where the reported array size equals the ``max_iterations`` value
+passed to the loop. This warning is purely diagnostic: the gradient
+computed for that run is still wrong, and the fix is to raise the
+bound and re-run.
+
+**Loop-invariant state variables.** The general path strips
+loop-invariant state variables and does not allocate trajectory
+storage for them, so users do not have to manually prune such
+variables from the loop state.
+
+**Incompatibility with compression.** The ``compress=True`` option of
+:py:func:`dr.while_loop() <while_loop>` removes inactive lanes between
+iterations and therefore breaks the fixed iteration-to-slot mapping
+that trajectory replay relies on. Combining it with ``max_iterations > 0``
+is rejected at loop-construction time.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -95,6 +95,12 @@ DrJit 1.4.0 (TBA)
   (Dr.Jit commit `6c69ec <https://github.com/mitsuba-renderer/drjit/commit/6c69ecb75cfc605063502747e9c9264bc739ead9>`__,
   Dr.Jit-Core commit `d4f1a6 <https://github.com/mitsuba-renderer/drjit-core/commit/d4f1a62c6b175af295e857069b1401c36bcf6caa>`__).
 
+- **Reverse-mode differentiation of symbolic loops**:
+  :py:func:`@dr.syntax <syntax>` ``while`` loops and symbolic
+  :py:func:`dr.while_loop() <while_loop>` calls are now differentiable in
+  reverse mode via a trajectory-replay strategy. See
+  :ref:`diff_loops` for details.
+
 **Performance Improvements**
 
 - **ndarray Cleanup**: ndarray reclamation previously always went through an

--- a/src/extra/loop.cpp
+++ b/src/extra/loop.cpp
@@ -530,6 +530,7 @@ public:
            ad_loop_body body_cb, ad_loop_delete delete_cb,
            const index64_vector &state,
            const dr::vector<uint32_t> &implicit_in,
+           const dr::vector<bool> &invariant_mask,
            long long max_iterations)
         : m_backend(backend), m_name(name), m_payload(payload),
           m_read_cb(read_cb), m_write_cb(write_cb), m_cond_cb(cond_cb),
@@ -545,6 +546,7 @@ public:
             VarType vt = jit_var_type(jit_index);
             Input input{};
             input.index = jit_index;
+            input.is_invariant = i < invariant_mask.size() && invariant_mask[i];
 
             if (vt == VarType::Float16 || vt == VarType::Float32 ||
                 vt == VarType::Float64) {
@@ -737,13 +739,16 @@ public:
     // -------------------------------------------------------------------
 
     void backward() override {
-        if (m_max_iterations == -1) {
+        if (m_max_iterations == -1)
             backward_simple();
-        } else {
-            jit_raise("CustomOp::backward(): the reverse-mode derivative of a "
-                      "complex loop (with max_iterations != -1) is not yet "
-                      "implemented!");
-        }
+        else if (m_max_iterations > 0)
+            backward_general();
+        else
+            jit_raise("LoopOp::backward(): reverse-mode differentiation of "
+                      "this loop requires a 'max_iterations' hint (either "
+                      "-1 for the sum-style fast path, or a positive upper "
+                      "bound on the iteration count to enable trajectory "
+                      "storage).");
     }
 
     // -------------------------------------------------------------------
@@ -862,7 +867,10 @@ public:
             if (in.has_grad_in && in.has_grad_out)
                 jit_raise("LoopOp::backward_simple(): unsupported "
                           "configuration. Variable %u (r%u) is marked both as a "
-                          "differentiable output and an input.", index, (uint32_t) in.index);
+                          "differentiable output and an input. Pass an "
+                          "'max_iterations' hint to the loop to enable the "
+                          "general-purpose reverse-mode implementation.",
+                          index, (uint32_t) in.index);
 
             if (in.has_grad_in) {
                 uint64_t zero = 0;
@@ -909,12 +917,282 @@ public:
         m_state.release();
     }
 
+    // -------------------------------------------------------------------
+
+    /* The backward_general() implementation stores the per-iteration state
+       of each differentiable (and non-differentiable) loop variable in a
+       per-thread variable array during a first forward-replay pass. A second
+       reverse replay then walks the recorded states in reverse, rebuilds a
+       one-iteration AD subgraph, and propagates gradients back through it.
+
+       The layout of 'm_state' during the two passes is:
+
+         pass 1 ("trajectory"):
+            [0 .. N)         : current (non-AD) loop state
+            [N .. 2*N)       : per-state-var trajectory arrays
+            [2*N]            : iteration counter 'it' (starts at 0)
+
+         pass 2 ("replay"):
+            [0 .. N)         : trajectory arrays (read-only)
+            [N]              : iteration counter 'it' (starts at pass-1 final)
+            [N+1 .. N+1+D)   : per-diff-state gradient accumulators
+
+       where N = m_inputs.size() and D = m_diff_count. */
+
+    uint32_t bwd_gen_p1_cond() {
+        size_t N = m_inputs.size();
+
+        m_state2.release();
+        for (size_t i = 0; i < N; ++i)
+            m_state2.push_back_borrow(m_state[i]);
+        m_write_cb(m_payload, m_state2, m_reset);
+        m_reset = false;
+        m_state2.release();
+
+        uint32_t user_cond = m_cond_cb(m_payload);
+
+        // In debug mode, return the user's condition unaltered. Overflow
+        // past m_max_iterations then trips jit_array_write()'s bounds check
+        // inside bwd_gen_p1_body(), logging a warning per overrun iteration.
+        if (jit_flag(JitFlag::Debug))
+            return user_cond;
+
+        // Release mode: cap the loop at m_max_iterations to keep trajectory
+        // writes in bounds.
+        uint32_t max_u32 = jit_var_u32(m_backend, (uint32_t) m_max_iterations);
+        uint32_t lt = jit_var_lt((uint32_t) m_state[2 * N], max_u32);
+        jit_var_dec_ref(max_u32);
+        uint32_t combined = jit_var_and(user_cond, lt);
+        jit_var_dec_ref(lt);
+        return combined;
+    }
+
+    void bwd_gen_p1_body() {
+        size_t N = m_inputs.size();
+        uint32_t iter = (uint32_t) m_state[2 * N];
+        uint32_t true_mask = jit_var_bool(m_backend, true);
+
+        // Record the pre-iteration state of each variable
+        for (size_t i = 0; i < N; ++i) {
+            if (m_inputs[i].is_invariant)
+                continue;
+            uint32_t arr = (uint32_t) m_state[N + i];
+            uint32_t value = (uint32_t) m_state[i];
+            uint32_t arr_new = jit_array_write(arr, iter, value, true_mask);
+            jit_var_dec_ref(arr);
+            m_state[N + i] = arr_new;
+        }
+        jit_var_dec_ref(true_mask);
+
+        // Execute the user body, discarding side effects
+        {
+            scoped_record record_guard(m_backend);
+            m_body_cb(m_payload);
+        }
+
+        // Read back the updated state (strip any AD that may have appeared)
+        m_state2.release();
+        m_read_cb(m_payload, m_state2);
+        for (size_t i = 0; i < N; ++i) {
+            uint32_t new_jit = (uint32_t) m_state2[i];
+            jit_var_inc_ref(new_jit);
+            jit_var_dec_ref((uint32_t) m_state[i]);
+            m_state[i] = new_jit;
+        }
+        m_state2.release();
+
+        // Advance the iteration counter
+        uint32_t one = jit_var_u32(m_backend, 1);
+        uint32_t iter_new = jit_var_add(iter, one);
+        jit_var_dec_ref(one);
+        jit_var_dec_ref(iter);
+        m_state[2 * N] = iter_new;
+    }
+
+    uint32_t bwd_gen_p2_cond() {
+        size_t N = m_inputs.size();
+        uint32_t iter = (uint32_t) m_state[N];
+        uint32_t zero = jit_var_u32(m_backend, 0);
+        uint32_t gt = jit_var_gt(iter, zero);
+        jit_var_dec_ref(zero);
+        return gt;
+    }
+
+    void bwd_gen_p2_body() {
+        size_t N = m_inputs.size();
+
+        // Decrement 'it' to the iteration we're about to backprop through
+        uint32_t iter = (uint32_t) m_state[N];
+        uint32_t one = jit_var_u32(m_backend, 1);
+        uint32_t iter_new = jit_var_sub(iter, one);
+        jit_var_dec_ref(one);
+        jit_var_dec_ref(iter);
+        m_state[N] = iter_new;
+
+        // Rebuild the per-iteration pre-body state from the trajectory.
+        // Invariants skip the trajectory (their value is constant, cached
+        // in in.index) but still get a fresh Symbolic AD wrap each iteration.
+        uint32_t true_mask = jit_var_bool(m_backend, true);
+        m_state2.release();
+        for (size_t i = 0; i < N; ++i) {
+            const Input &in = m_inputs[i];
+            uint64_t index;
+            uint32_t val;
+            if (in.is_invariant) {
+                val = in.index;
+                jit_var_inc_ref(val);
+            } else {
+                uint32_t arr = (uint32_t) m_state[i];
+                val = jit_array_read(arr, iter_new, true_mask);
+            }
+            if (in.is_diff) {
+                index = ad_var_new(val);
+                jit_var_dec_ref(val);
+            } else {
+                index = val;
+            }
+            m_state2.push_back_steal(index);
+        }
+        jit_var_dec_ref(true_mask);
+
+        // Push to Python, run the body with side effects suppressed
+        m_write_cb(m_payload, m_state2, true);
+        {
+            scoped_record record_guard(m_backend);
+            m_body_cb(m_payload);
+        }
+
+        // Read back the body's outputs (AD-equipped)
+        index64_vector out;
+        m_read_cb(m_payload, out);
+
+        // Seed gradients on the outputs from the running accumulators
+        size_t diff_off = N + 1;
+        for (size_t i = 0; i < N; ++i) {
+            const Input &in = m_inputs[i];
+            if (!in.is_diff)
+                continue;
+            if (out[i] >> 32) {
+                ad_accum_grad(out[i], (uint32_t) m_state[diff_off]);
+                ad_enqueue(dr::ADMode::Backward, out[i]);
+            }
+            diff_off++;
+        }
+
+        ad_traverse(dr::ADMode::Backward, (uint32_t) dr::ADFlag::ClearNone);
+
+        // New accumulator values = gradient of the fresh per-iteration inputs
+        diff_off = N + 1;
+        for (size_t i = 0; i < N; ++i) {
+            const Input &in = m_inputs[i];
+            if (!in.is_diff)
+                continue;
+            uint32_t new_grad = ad_grad(m_state2[i]);
+            jit_var_dec_ref((uint32_t) m_state[diff_off]);
+            m_state[diff_off] = new_grad;
+            diff_off++;
+        }
+
+        out.release();
+        m_state2.release();
+    }
+
+    void backward_general() {
+        size_t N = m_inputs.size();
+        size_t max_iter = (size_t) m_max_iterations;
+
+        // Pass 1: record the trajectory
+        std::string name_p1 = m_name + " [ad, bwd, record]";
+
+        m_state.release();
+        for (const Input &in : m_inputs)
+            m_state.push_back_borrow(in.index);
+        for (const Input &in : m_inputs) {
+            // Invariants get a unit-capacity placeholder (never written);
+            // pass 2 substitutes in.index directly without touching it.
+            size_t capacity = in.is_invariant ? 1 : max_iter;
+            uint32_t arr = jit_array_create(m_backend, jit_var_type(in.index), 1,
+                                            capacity);
+            m_state.push_back_steal(arr);
+        }
+        m_state.push_back_steal(jit_var_u32(m_backend, 0));
+
+        ad_loop(
+            m_backend, 1, 0, 0, name_p1.c_str(), this,
+            [](void *p, dr::vector<uint64_t> &i) { ((LoopOp *) p)->read(i); },
+            [](void *p, const dr::vector<uint64_t> &i, bool reset) { ((LoopOp *) p)->write(i, reset); },
+            [](void *p) { return ((LoopOp *) p)->bwd_gen_p1_cond(); },
+            [](void *p) { ((LoopOp *) p)->bwd_gen_p1_body(); },
+            nullptr, false);
+
+        // Reshape m_state for pass 2: [traj] + [it] + [grad accumulators].
+        // Copy out the entries we want to keep (with +1 ref), release
+        // m_state, then push them back. m_state contains jit-only indices
+        // throughout both passes, so jit_var_inc_ref is enough.
+        dr::vector<uint32_t> keep(N + 1);
+        for (size_t i = 0; i < N; ++i) {
+            keep[i] = (uint32_t) m_state[N + i];  // trajectory arrays
+            jit_var_inc_ref(keep[i]);
+        }
+        keep[N] = (uint32_t) m_state[2 * N];      // final iteration counter
+        jit_var_inc_ref(keep[N]);
+        m_state.release();
+
+        for (uint32_t idx : keep)
+            m_state.push_back_steal(idx);
+
+        size_t loop_size = jit_var_size(keep[N]);
+        for (const Input &in : m_inputs) {
+            if (!in.is_diff)
+                continue;
+            uint32_t grad;
+            if (in.has_grad_out) {
+                grad = ad_grad(combine(m_output_indices[in.grad_out_offset]));
+            } else {
+                uint64_t zero = 0;
+                grad = jit_var_literal(m_backend, jit_var_type(in.index),
+                                       &zero, loop_size);
+            }
+            m_state.push_back_steal(grad);
+        }
+
+        // Pass 2: replay the trajectory in reverse, propagating gradients
+        std::string name_p2 = m_name + " [ad, bwd, replay]";
+
+        ad_loop(
+            m_backend, 1, 0, 0, name_p2.c_str(), this,
+            [](void *p, dr::vector<uint64_t> &i) { ((LoopOp *) p)->read(i); },
+            [](void *p, const dr::vector<uint64_t> &i, bool reset) { ((LoopOp *) p)->write(i, reset); },
+            [](void *p) { return ((LoopOp *) p)->bwd_gen_p2_cond(); },
+            [](void *p) { ((LoopOp *) p)->bwd_gen_p2_body(); },
+            nullptr, false);
+
+        // Accumulate final gradients into the loop's differentiable inputs
+        size_t diff_off = N + 1;
+        for (size_t i = 0; i < N; ++i) {
+            const Input &in = m_inputs[i];
+            if (!in.is_diff)
+                continue;
+            if (in.has_grad_in)
+                ad_accum_grad(combine(m_input_indices[in.grad_in_index]),
+                              (uint32_t) m_state[diff_off]);
+            diff_off++;
+        }
+
+        m_state.release();
+    }
+
 private:
     struct Input {
         uint32_t index;
 
         /// Is this variable differentiable in principle?
         bool is_diff;
+
+        /// Same JIT index pre/post: value is constant across iterations.
+        /// Invariants skip trajectory storage in reverse-mode trajectory
+        /// replay and substitute the constant value directly instead.
+        bool is_invariant;
 
         /// Does the loop op. receive gradients for this variable?
         bool has_grad_in;
@@ -984,8 +1262,14 @@ bool ad_loop(JitBackend backend, int symbolic, int compress,
     if (compress != 0 && compress != 1)
         jit_raise("'compress' must equal 0, 1, or -1.");
 
-    if (max_iterations < -1)
-        jit_raise("'max_iterations' must be >= -1.");
+    if (max_iterations < -1 || max_iterations > (long long) UINT32_MAX)
+        jit_raise("'max_iterations' must be in [-1, 2^32 - 1].");
+
+    if (compress == 1 && max_iterations > 0)
+        jit_raise("'compress=True' and 'max_iterations > 0' cannot be "
+                  "combined. The reverse-mode trajectory replay requires "
+                  "a stable mapping between iteration number and trajectory "
+                  "slot, which compression breaks.");
 
     if (symbolic) {
         index64_vector indices_in;
@@ -1021,10 +1305,16 @@ bool ad_loop(JitBackend backend, int symbolic, int compress,
             index64_vector indices_out;
             read_cb(payload, indices_out);
 
+            // Detect loop-invariant state variables (same JIT index pre/post)
+            dr::vector<bool> invariant_mask(indices_out.size(), false);
+            for (size_t i = 0; i < indices_out.size(); ++i)
+                invariant_mask[i] =
+                    (uint32_t) indices_in[i] == (uint32_t) indices_out[i];
+
             nanobind::ref<LoopOp> op =
                 new LoopOp(backend, name, payload, read_cb, write_cb,
                            cond_cb, body_cb, delete_cb, indices_in,
-                           implicit_in, max_iterations);
+                           implicit_in, invariant_mask, max_iterations);
 
             for (size_t i = 0; i < indices_out.size(); ++i) {
                 VarType vt = jit_var_type((uint32_t) indices_out[i]);
@@ -1032,7 +1322,7 @@ bool ad_loop(JitBackend backend, int symbolic, int compress,
                     vt != VarType::Float64)
                     continue;
 
-                if ((uint32_t) indices_in[i] == (uint32_t) indices_out[i]) {
+                if (invariant_mask[i]) {
                     // Keep unchanged variables out of the AD system
                     if (indices_in[i] != indices_out[i]) {
                         ad_var_inc_ref(indices_in[i]);

--- a/tests/test_while_loop_ad.py
+++ b/tests/test_while_loop_ad.py
@@ -263,3 +263,375 @@ def test32_simple_loop(t, mode):
 
     dr.backward(q)
     assert dr.all(x.grad == [1]*10)
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@dr.syntax
+def test33_general_bwd_scaling(t):
+    # y_out = y_in * 2^N. Straight reverse-mode case that backward_simple
+    # cannot handle (iterations compose multiplicatively, not additively).
+    UInt = dr.uint32_array_t(t)
+
+    x = t(1.0, 2.0, 3.0, 4.0)
+    dr.enable_grad(x)
+    y = t(x)
+    i = UInt(0)
+
+    while dr.hint(i < 3, mode='symbolic', max_iterations=3):
+        y = y * 2
+        i += 1
+
+    dr.backward_from(y)
+    assert dr.allclose(x.grad, [8, 8, 8, 8])
+    assert dr.allclose(y, [8, 16, 24, 32])
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@dr.syntax
+def test34_general_bwd_fwd_cross_check(t):
+    # Non-sum loop: each step is y_new = (y + 1) * x, so after N iterations
+    # starting from y=0, y = x + x^2 + ... + x^N. Compare reverse-mode
+    # through backward_general against forward-mode AD (which is independent
+    # of the new code path).
+    UInt = dr.uint32_array_t(t)
+
+    def run(x_in):
+        y = t(0.0)
+        i = UInt(0)
+        while dr.hint(i < 4, mode='symbolic', max_iterations=4):
+            y = (y + 1) * x_in
+            i += 1
+        return y
+
+    x_fwd = t(1.1, 1.3, 1.7, 2.1)
+    dr.enable_grad(x_fwd)
+    dr.set_grad(x_fwd, 1.0)
+    y_fwd = run(x_fwd)
+    dr.forward_to(y_fwd)
+    fwd_grad = t(y_fwd.grad)
+
+    x_bwd = t(1.1, 1.3, 1.7, 2.1)
+    dr.enable_grad(x_bwd)
+    y_bwd = run(x_bwd)
+    dr.backward_from(y_bwd)
+    assert dr.allclose(x_bwd.grad, fwd_grad)
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@dr.syntax
+def test35_general_bwd_per_thread_iter_count(t):
+    # Per-lane iteration count: lane k runs k+1 iterations of y = y * 2,
+    # driven by an int state var. backward_general must back off per lane.
+    UInt = dr.uint32_array_t(t)
+
+    x = t(1.0, 2.0, 3.0, 4.0)
+    dr.enable_grad(x)
+    y = t(x)
+    i = UInt(0)
+    n = UInt(1, 2, 3, 4)
+
+    while dr.hint(i < n, mode='symbolic', max_iterations=4):
+        y = y * 2
+        i += 1
+
+    dr.backward_from(y)
+    # dy/dx per lane = 2^n[k]
+    assert dr.allclose(x.grad, [2.0, 4.0, 8.0, 16.0])
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@dr.syntax
+def test36_general_bwd_fibonacci(t):
+    # Non-additive coupling between state variables (Fibonacci-style).
+    # a_{k+1} = b_k,  b_{k+1} = a_k + b_k. After 3 iterations:
+    #   a_3 = 1*a_0 + 2*b_0,  b_3 = 2*a_0 + 3*b_0.
+    # Therefore ∂(a_3 + b_3)/∂a_0 = 3, ∂(a_3 + b_3)/∂b_0 = 5.
+    UInt = dr.uint32_array_t(t)
+
+    a = t(1.0, 2.0)
+    b = t(3.0, 5.0)
+    dr.enable_grad(a, b)
+    a0, b0 = t(a), t(b)
+    i = UInt(0)
+
+    while dr.hint(i < 3, mode='symbolic', max_iterations=3):
+        a, b = b, a + b
+        i += 1
+
+    dr.backward_from(a + b)
+    assert dr.allclose(a0.grad, [3.0, 3.0])
+    assert dr.allclose(b0.grad, [5.0, 5.0])
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@dr.syntax
+def test37_general_bwd_matches_simple(t):
+    # Sum-loop pattern: both backward_simple (max_iterations=-1) and
+    # backward_general (max_iterations=10) should produce the same gradient.
+    UInt = dr.uint32_array_t(t)
+
+    def run(max_it):
+        x = dr.linspace(t, 0.25, 1, 4)
+        dr.enable_grad(x)
+        y = t(0.0)
+        i = UInt(0)
+        while dr.hint(i < 10, mode='symbolic', max_iterations=max_it):
+            y += x ** i
+            i += 1
+        dr.backward_from(y)
+        return x.grad
+
+    g_simple = run(-1)
+    g_general = run(10)
+    assert dr.allclose(g_simple, g_general)
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@dr.syntax
+def test38_general_bwd_compress_rejected(t):
+    # compress=True + max_iterations>0 combination is rejected by ad_loop.
+    UInt = dr.uint32_array_t(t)
+
+    x = t(1.0, 2.0)
+    dr.enable_grad(x)
+    y = t(x)
+    i = UInt(0)
+
+    with pytest.raises(RuntimeError, match='compress'):
+        while dr.hint(i < 2, mode='symbolic', max_iterations=2, compress=True):
+            y = y * 2
+            i += 1
+        dr.backward_from(y)
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@dr.syntax
+def test39_general_bwd_nested(t):
+    # Nested differentiable loops, both with positive max_iterations. Verifies
+    # that an inner symbolic loop within a trajectory-recording outer backward
+    # pass composes cleanly.  a_final = x^2 * (x+1)^2 in closed form, so
+    # dx/da_final = 2*x*(x+1)*(2*x+1).
+    UInt = dr.uint32_array_t(t)
+
+    x = t(2.0, 1.5)
+    dr.enable_grad(x)
+
+    a = t(1.0, 1.0)
+    b = t(x)
+    j = UInt(0)
+    while dr.hint(j < 2, mode='symbolic', max_iterations=2):
+        i = UInt(0)
+        while dr.hint(i < 2, mode='symbolic', max_iterations=2):
+            a = a * b
+            i += 1
+        b = b + 1.0
+        j += 1
+
+    dr.backward_from(a)
+    xv = t(2.0, 1.5)
+    expected = 2 * xv * (xv + 1) * (2 * xv + 1)
+    assert dr.allclose(x.grad, expected)
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@dr.syntax
+def test40_general_bwd_missing_hint_rejected(t):
+    # A loop with non-sum-pattern reverse-mode AD and no max_iterations hint
+    # must raise a clear error rather than silently producing wrong gradients.
+    UInt = dr.uint32_array_t(t)
+
+    x = t(1.0, 2.0)
+    dr.enable_grad(x)
+    y = t(x)
+    i = UInt(0)
+
+    with pytest.raises(RuntimeError, match='max_iterations'):
+        while dr.hint(i < 2, mode='symbolic'):
+            y = y * 2
+            i += 1
+        dr.backward_from(y)
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+def test41_general_bwd_gather(t):
+    # gather() from an external grad-enabled buffer inside a non-sum loop
+    # (max_iterations>0). Gradients to the external buffer flow via the AD
+    # graph walked by pass 2's ad_traverse(Backward); no special handling
+    # in backward_general is required because gradient reaches implicit
+    # inputs naturally through graph connectivity.
+    #
+    # Body: y = y * table[i]; i += 1
+    # After 3 iters: y_3 = table[0] * table[1] * table[2]
+    # Loss = sum(y_3) over 4 lanes (each lane produces the same y_3 = 24)
+    # dL/dtable[k] = (lanes) * product of other table entries
+    #
+    # Note: the loop is written without @dr.syntax so that `table` stays a
+    # closure capture (implicit input) rather than being promoted into the
+    # loop state, which is what we want to exercise here.
+    UInt = dr.uint32_array_t(t)
+
+    table = t(2.0, 3.0, 4.0, 5.0)
+    dr.enable_grad(table)
+
+    y = t(1.0, 1.0, 1.0, 1.0)
+    i = UInt(0)
+
+    def cond(i, y):
+        return i < 3
+    def body(i, y):
+        return i + 1, y * dr.gather(t, table, i)
+
+    i, y = dr.while_loop((i, y), cond, body,
+                         mode='symbolic', max_iterations=3)
+
+    dr.backward_from(dr.sum(y))
+    # dL/dtable[0] = 4 * 3*4 = 48
+    # dL/dtable[1] = 4 * 2*4 = 32
+    # dL/dtable[2] = 4 * 2*3 = 24
+    # dL/dtable[3] = 0
+    assert dr.allclose(table.grad, [48, 32, 24, 0])
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+def test42_general_bwd_overflow_debug_warns(t, capsys):
+    # When the user underestimates max_iterations, backward_general silently
+    # truncates in release mode (accepted behavior). In debug mode the
+    # trajectory-array-write bounds check fires and logs a warning, so the
+    # user can spot the undersized hint.
+    UInt = dr.uint32_array_t(t)
+
+    # The body must produce a gradient that actually references the trajectory
+    # values (here: y_new = y*z), otherwise the trajectory write chain isn't
+    # reached during AD evaluation and no warning is needed.
+    y = t(1.0, 2.0)
+    z = t(3.0, 4.0)
+    dr.enable_grad(y, z)
+    i = UInt(0)
+
+    with dr.scoped_set_flag(dr.JitFlag.Debug, True):
+        def cond(i, y, z):
+            return i < 5
+        def body(i, y, z):
+            return i + 1, y * z, z
+        # The user's condition wants 5 iterations but max_iterations=3.
+        i, y, z = dr.while_loop((i, y, z), cond, body,
+                                 mode='symbolic', max_iterations=3)
+        dr.backward_from(y)
+        dr.eval(z.grad)  # force eval so the bounds-check callback fires
+
+    transcript = capsys.readouterr().err
+    assert 'out-of-bounds write' in transcript
+    assert 'array of size 3' in transcript
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+def test43_general_bwd_invariant_passengers(t, drjit_verbose, capsys):
+    # Many differentiable "passenger" state variables that never change in the
+    # body. They should not trigger max_iterations-sized trajectory storage,
+    # yet gradients through them must still be correct. The verbose log is
+    # used to count per-iteration trajectory writes: only the two non-invariant
+    # state variables (i, y) must appear in `array_write` operations.
+    UInt = dr.uint32_array_t(t)
+
+    N_PASSENGERS = 32
+    MAX_ITER = 4
+
+    size = 3
+    x = dr.linspace(t, 1.5, 2.5, size)
+    dr.enable_grad(x)
+
+    passengers = tuple(dr.full(t, float(k + 1), size) for k in range(N_PASSENGERS))
+    for p in passengers:
+        dr.enable_grad(p)
+    passengers_in = tuple(t(p) for p in passengers)
+
+    y = dr.ones(t, size)
+    i = dr.zeros(UInt, size)
+
+    def cond(i, y, x, *ps):
+        return i < MAX_ITER
+
+    def body(i, y, x, *ps):
+        # Body uses only x and ps[0]; ps[1:] are pure ballast invariants.
+        return (i + 1, y * x * ps[0], x) + ps
+
+    capsys.readouterr()  # drop setup log
+    state_out = dr.while_loop((i, y, x) + passengers, cond, body,
+                              mode='symbolic', max_iterations=MAX_ITER)
+    y_out = state_out[1]
+    dr.backward_from(dr.sum(y_out))
+    dr.eval(x.grad)
+
+    # Only (i, y) change during the loop body. The other 1+N_PASSENGERS state
+    # variables are JIT-invariant and must be excised from trajectory storage.
+    # The pass-1 body is recorded twice (the symbolic loop re-records once),
+    # so each non-invariant contributes 2 array_writes.
+    log = capsys.readouterr().out
+    assert log.count('array_write') == 2 * 2  # (i, y) * 2 passes
+
+    # dL/dx and dL/dpassengers[0] should be nonzero; ps[1:] receive zero grad.
+    assert dr.all(x.grad != 0)
+    assert dr.all(passengers_in[0].grad != 0)
+    for k in range(1, N_PASSENGERS):
+        assert dr.all(passengers_in[k].grad == 0)
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+def test44_general_bwd_matrix_sqrt_newton(t):
+    # Newton iteration for the matrix square root:
+    #   Y_{k+1} = 0.5 * (Y_k + A @ Y_k^-1),  Y_0 = A.
+    # Converges quadratically to sqrt(A) for positive-definite A. A matrix
+    # inverse in every step makes this a strongly nonlinear loop body. We
+    # check that the loop converges to sqrt(A), and that reverse-mode AD
+    # agrees with forward-mode AD along a random symmetric probe direction.
+    mod = sys.modules[t.__module__]
+    M4 = mod.Matrix4f
+    UInt = dr.uint32_array_t(t)
+
+    NUM_ITER = 6
+
+    def sqrt_loop(A):
+        Y = M4(A)
+        i = UInt(0)
+        def cond(Y, i, A):
+            return i < NUM_ITER
+        def body(Y, i, A):
+            return (0.5 * (Y + A @ dr.rcp(Y)), i + 1, A)
+        Y, _, _ = dr.while_loop((Y, i, A), cond, body,
+                                mode='symbolic', max_iterations=NUM_ITER)
+        return Y
+
+    # Positive-definite A = M M^T for a well-conditioned M.
+    M_base = M4([[1.0, 0.1, 0.2, 0.0],
+                 [0.1, 1.2, 0.1, 0.1],
+                 [0.2, 0.1, 1.3, 0.1],
+                 [0.0, 0.1, 0.1, 1.1]])
+    A_base = M_base @ M_base.T
+
+    # Primal: Y @ Y should recover A.
+    Y = sqrt_loop(A_base)
+    dr.assert_allclose(Y @ Y, A_base, atol=1e-5)
+
+    # Symmetric probe direction for the Jacobian check.
+    dA = M4([[ 0.30, -0.10,  0.20,  0.05],
+             [-0.10,  0.20,  0.00,  0.15],
+             [ 0.20,  0.00,  0.10, -0.10],
+             [ 0.05,  0.15, -0.10,  0.25]])
+    dA = 0.5 * (dA + dA.T)
+
+    # Reverse mode: gradient of L = trace(Y) with respect to every entry of A.
+    A_bwd = M4(A_base)
+    dr.enable_grad(A_bwd)
+    L_bwd = dr.trace(sqrt_loop(A_bwd))
+    dr.backward_from(L_bwd)
+    bwd_probe = dr.trace(dr.grad(A_bwd).T @ dA)
+
+    # Forward mode: seed A.grad = dA, compute dL/d(epsilon).
+    A_fwd = M4(A_base)
+    dr.enable_grad(A_fwd)
+    dr.set_grad(A_fwd, dA)
+    L_fwd = dr.trace(sqrt_loop(A_fwd))
+    dr.forward_to(L_fwd)
+    fwd_probe = dr.grad(L_fwd)
+
+    dr.assert_allclose(bwd_probe, fwd_probe, rtol=1e-4)


### PR DESCRIPTION
Prior to this commit, general Dr.Jit symbolic loops could only be differentiated in forward mode. Reverse mode was restricted to a simple case where the body's contributions compose additively (a "sum" loop).

This commit adds a general replay path, activated by a positive ``'max_iterations'`` hint on ``dr.while_loop()``. The implementation uses two symbolic passes:

  Pass 1 (record): runs the loop forward, writing the state of every loop variable into per-thread variable arrays on the stack.

  Pass 2 (replay): re-runs the loop in reverse, while reading the previously recorded state and propagating derivatives.

Both passes reuse the existing symbolic loop infrastructure.

The new general approach must know the maximum number of loop iterations so that it can provision the necessary amount of stack memory. This is done through the ``max_iterations`` hint:

  - ``max_iterations=-1`` selects the existing sum-path which stays the fast default for additive loops.

  - ``max_iterations>0`` selects the general approach and provisions ``max_iterations * sizeof(loop state)`` of stack memory.

  - Other values including the default raise an error message when differentiated in reverse mode.

Loops, whose number of maximum iterations exceeds the ``max_iterations`` hint produce incorrect (but consistent, i.e., no UB) reverse mode derivatives. Debug mode (``JitFlag::Debug``) catches iteration overflows and fires a warning.

The commit adds a number of tests involving simple and complex differentiable loops, nested loops, loops with gathers, etc.