### PR TITLE
Add normalization mode to dr.convolve

### DIFF
--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -1940,7 +1940,8 @@ def convolve(
     source: ArrayT,
     filter: Union[Literal["box", "linear", "hamming", "cubic", "lanczos", "gaussian"], Callable[[float], float]],
     filter_radius: float,
-    axis: Union[int, Tuple[int, ...], None] = None
+    axis: Union[int, Tuple[int, ...], None] = None,
+    normalize: Literal["l1", "l2"] = "l1"
 ) -> ArrayT:
     """
     Convolve one or more axes of an input array/tensor with a 1D filter
@@ -1959,8 +1960,10 @@ def convolve(
            filter_radius=10
        )
 
-    The filter weights are renormalized to reduce edge effects near the
-    boundary of the array.
+    By default, the filter weights are renormalized to sum to one
+    (``normalize="l1"``) to reduce edge effects near the boundary of the array.
+    Setting ``normalize="l2"`` instead scales the sampled filter weights to
+    unit L2 norm.
 
     The function supports a set of provided filters, and custom filters
     can also be specified. This works analogously to the :py:func:`resample`
@@ -1980,6 +1983,10 @@ def convolve(
         axis (int | tuple[int, ...] | ... | None): The axis or set of axes
           along which to convolve. The default argument ``axis=None`` causes all
           axes to be convolved. Negative values count from the last dimension.
+
+        normalize (str): How to normalize the sampled filter weights. Supported
+          values are ``"l1"`` for unit sum and ``"l2"`` for unit L2 norm. The
+          default is ``"l1"``.
 
     Returns:
         drjit.ArrayBase: The resampled output array. Its type matches ``source``.
@@ -2002,7 +2009,7 @@ def convolve(
         res = shape[i]
 
         # Cache resampler in case it can be reused
-        key = (res, res, filter, filter_radius)
+        key = (res, res, filter, filter_radius, normalize)
 
         resampler = _resample_cache.get(key, None)
         if resampler is None:
@@ -2011,7 +2018,8 @@ def convolve(
                 target_res=res,
                 filter=filter,
                 filter_radius=filter_radius,
-                convolve=True
+                convolve=True,
+                normalize=normalize
             )
             _resample_cache[key] = resampler
 

--- a/include/drjit/resample.h
+++ b/include/drjit/resample.h
@@ -29,6 +29,10 @@ NAMESPACE_BEGIN(drjit)
 class DRJIT_EXTRA_EXPORT Resampler {
 public:
     using Filter = double (*)(double x, const void *payload);
+    enum class FilterNormalization {
+        L1,
+        L2
+    };
 
     /**
      * Create a Resampler that uses a predefined reconstruction filter to
@@ -66,7 +70,8 @@ public:
      * filter kernel radius.
      */
     Resampler(uint32_t source_res, uint32_t target_res, const char *filter,
-              double radius_scale = 1.0);
+              double radius_scale = 1.0,
+              FilterNormalization normalize = FilterNormalization::L1);
 
     /**
      * \brief Construct a Resampler using a custom filter kernel.
@@ -80,7 +85,8 @@ public:
      * zero for positions ``x`` outside of the interval ``[-radius, radius]``.
      */
     Resampler(uint32_t source_res, uint32_t target_res, Filter filter,
-              const void *payload, double radius);
+              const void *payload, double radius,
+              FilterNormalization normalize = FilterNormalization::L1);
 
     /// Free the resampler object
     ~Resampler();

--- a/src/extra/resample.cpp
+++ b/src/extra/resample.cpp
@@ -29,7 +29,8 @@ struct Resampler::Impl {
     mutable std::any weights_cache;
 
     Impl(uint32_t source_res, uint32_t target_res, Resampler::Filter filter,
-         const void *payload, double radius, double radius_scale)
+         const void *payload, double radius, double radius_scale,
+         Resampler::FilterNormalization normalize)
         : source_res(source_res), target_res(target_res) {
         if (source_res == 0 || target_res == 0)
             drjit_raise("drjit.Resampler(): source/target resolution cannot be zero!");
@@ -62,7 +63,8 @@ struct Resampler::Impl {
                 (uint32_t) std::max(0, (int) (center - radius + .5));
             offset[i] = offset_i;
 
-            double sum = 0.0;
+            double sum = 0.0,
+                   sum_sqr = 0.0;
             for (uint32_t l = 0; l < taps; l++) {
                 // Relative position of sample in the filter frame
                 double rel = (offset_i - center + l + .5) * filter_scale;
@@ -72,16 +74,21 @@ struct Resampler::Impl {
                     weight = filter(rel, payload);
                 weights[i * taps + l] = weight;
                 sum += weight;
+                sum_sqr += weight * weight;
             }
 
-            if (sum == 0)
+            bool use_l2_normalization =
+                normalize == Resampler::FilterNormalization::L2;
+            if ((use_l2_normalization ? sum_sqr : sum) == 0)
                 drjit_raise(
                     "drjit.Resampler(): the filter footprint is too small; the "
                     "support of some output samples does not contain any input "
                     "samples!");
 
             // Normalize the weights for each output sample
-            double normalization = 1.0 / sum;
+            double normalization = use_l2_normalization
+                                       ? 1.0 / std::sqrt(sum_sqr)
+                                       : 1.0 / sum;
             for (uint32_t l = 0; l < taps; l++)
                 weights[i * taps + l] *= normalization;
         }
@@ -129,7 +136,8 @@ static inline double sinc(double x) {
     return std::sin(x) / x;
 }
 
-Resampler::Resampler(uint32_t source_res, uint32_t target_res, const char *filter, double radius_scale) {
+Resampler::Resampler(uint32_t source_res, uint32_t target_res, const char *filter,
+                     double radius_scale, Resampler::FilterNormalization normalize) {
     Resampler::Filter filter_cb = nullptr;
     double radius = 0.0;
 
@@ -191,13 +199,15 @@ Resampler::Resampler(uint32_t source_res, uint32_t target_res, const char *filte
                     "'hamming', 'cubic', and 'lanczos' are supported).");
     }
 
-    d = new Impl(source_res, target_res, filter_cb, nullptr, radius, radius_scale);
+    d = new Impl(source_res, target_res, filter_cb, nullptr, radius, radius_scale,
+                 normalize);
 }
 
 Resampler::Resampler(uint32_t source_res, uint32_t target_res,
                      Resampler::Filter filter, const void *payload,
-                     double radius)
-    : d(new Impl(source_res, target_res, filter, payload, radius, 1.0)) {
+                     double radius, Resampler::FilterNormalization normalize)
+    : d(new Impl(source_res, target_res, filter, payload, radius, 1.0,
+                 normalize)) {
 }
 
 Resampler::~Resampler() { }

--- a/src/python/resample.cpp
+++ b/src/python/resample.cpp
@@ -12,26 +12,43 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/optional.h>
 #include "common.h"
+#include <cstring>
 
 void export_resample(nb::module_ &) {
     nb::object detail = nb::module_::import_("drjit").attr("detail");
     using dr::Resampler;
 
+    auto parse_normalize = [](const char *normalize) {
+        if (strcmp(normalize, "l1") == 0)
+            return Resampler::FilterNormalization::L1;
+        else if (strcmp(normalize, "l2") == 0)
+            return Resampler::FilterNormalization::L2;
+        nb::raise("'normalize' must be either \"l1\" or \"l2\".");
+        return Resampler::FilterNormalization::L1;
+    };
+
     auto resampler = nb::class_<Resampler>(detail, "Resampler")
-        .def("__init__", [](Resampler *self, uint32_t source_res, uint32_t target_res,
-                            const char *filter, std::optional<double> filter_radius, bool convolve) {
+        .def("__init__", [parse_normalize](Resampler *self, uint32_t source_res, uint32_t target_res,
+                            const char *filter, std::optional<double> filter_radius,
+                            bool convolve, const char *normalize) {
                  if (filter_radius.has_value() && !convolve)
                      nb::raise("drjit.Resampler(): 'filter_radius' must be None when using a filter preset.");
-                 new (self) Resampler(source_res, target_res, filter, filter_radius.has_value() ? filter_radius.value() : 1.0);
-             }, "source_res"_a, "target_res"_a, "filter"_a, "filter_radius"_a = nb::none(), "convolve"_a = false)
-        .def("__init__", [](Resampler *self, uint32_t source_res, uint32_t target_res,
-                            nb::typed<nb::callable, float, float> filter, double filter_radius, bool) {
+                 new (self) Resampler(source_res, target_res, filter,
+                                      filter_radius.has_value() ? filter_radius.value() : 1.0,
+                                      parse_normalize(normalize));
+             }, "source_res"_a, "target_res"_a, "filter"_a, "filter_radius"_a = nb::none(), "convolve"_a = false,
+                "normalize"_a = "l1")
+        .def("__init__", [parse_normalize](Resampler *self, uint32_t source_res, uint32_t target_res,
+                            nb::typed<nb::callable, float, float> filter, double filter_radius,
+                            bool, const char *normalize) {
                  Resampler::Filter filter_cb = [](double v, const void *ptr) -> double {
                      return nb::cast<double>(nb::handle((PyObject *) ptr)(v));
                  };
                  new (self) Resampler(source_res, target_res, filter_cb,
-                                      filter.ptr(), filter_radius);
-             }, "source_res"_a, "target_res"_a, "filter"_a, "filter_radius"_a, "convolve"_a = false)
+                                      filter.ptr(), filter_radius,
+                                      parse_normalize(normalize));
+             }, "source_res"_a, "target_res"_a, "filter"_a, "filter_radius"_a, "convolve"_a = false,
+                "normalize"_a = "l1")
 #if defined(DRJIT_ENABLE_CUDA)
          .def("resample_fwd",
               (dr::CUDAArray<dr::half>(Resampler::*)(const dr::CUDAArray<dr::half> &, uint32_t) const) &Resampler::resample_fwd,

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -1,4 +1,5 @@
 import drjit as dr
+import math
 import pytest
 
 # Test simple upsampling with a box filter (1D array)
@@ -113,3 +114,24 @@ def test07_convolve(t):
     y = dr.convolve(x, 'linear', 2)
     z = t((1+2*.5)/1.5, (1*.5+2+10*.5)/2, (2*.5+10+100*.5)/2, (100+10*.5)/1.5)
     assert dr.allclose(y, z)
+
+
+# Test L2-normalized convolution weights sampled from a custom continuous filter
+@pytest.test_arrays('float, -jit, shape=(*)')
+def test08_convolve_normalize(t):
+    x = t([0, 0, 0, 0, 1, 0, 0, 0, 0])
+
+    def filt(x):
+        return max(2.0 - abs(x), 0.0)
+
+    y = dr.convolve(x, filt, 2)
+    z = t([0, 0, 0, .25, .5, .25, 0, 0, 0])
+    assert dr.allclose(y, z)
+
+    y = dr.convolve(x, filt, 2, normalize="l2")
+    s = 1.0 / math.sqrt(6.0)
+    z = t([0, 0, 0, s, 2.0 * s, s, 0, 0, 0])
+    assert dr.allclose(y, z)
+
+    with pytest.raises(RuntimeError, match="'normalize' must be either"):
+        dr.convolve(x, filt, 2, normalize="bad")


### PR DESCRIPTION
## Summary

This PR adds a `normalize` option to `dr.convolve`.

The default behavior remains unchanged:

```python
dr.convolve(..., normalize="l1")
```

This preserves the existing unit-sum normalization of sampled filter weights.

A new L2 normalization mode is added:

```python
dr.convolve(..., normalize="l2")
```

In this mode, sampled convolution weights are normalized by their L2 norm instead of their sum. This is useful when convolving white noise with a filter to construct covariance-controlled random fields, e.g. in GPIS sampling.

Implementation details

- Added normalize: Literal["l1", "l2"] = "l1" to dr.convolve.
- Added an internal Resampler::FilterNormalization enum with L1 and L2 modes.
- Updated the Python binding for detail.Resampler to parse "l1" and "l2".
- Kept boundary behavior consistent with the existing implementation: filter taps outside the source domain are discarded, and the remaining weights are renormalized.
- Added tests covering the default L1 behavior, the new L2 behavior, and invalid normalize values.