### PR TITLE
NumPy-compatible array/tensor manipulation and sorting

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -111,6 +111,12 @@ Rearranging array contents
 --------------------------
 
 .. autofunction:: concat
+.. autofunction:: stack
+.. autofunction:: vstack
+.. autofunction:: hstack
+.. autofunction:: column_stack
+.. autofunction:: dstack
+.. autofunction:: expand_dims
 .. autofunction:: reverse
 .. autofunction:: moveaxis
 .. autofunction:: take

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -117,8 +117,11 @@ Rearranging array contents
 .. autofunction:: column_stack
 .. autofunction:: dstack
 .. autofunction:: expand_dims
+.. autofunction:: squeeze
 .. autofunction:: reverse
 .. autofunction:: moveaxis
+.. autofunction:: transpose
+.. autofunction:: swapaxes
 .. autofunction:: take
 .. autofunction:: take_interp
 .. autofunction:: compress

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -83,6 +83,8 @@ Reductions
 .. autofunction:: std
 .. autofunction:: argmin
 .. autofunction:: argmax
+.. autofunction:: sort
+.. autofunction:: argsort
 
 .. autofunction:: all
 .. autofunction:: any

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -81,6 +81,8 @@ Reductions
 .. autofunction:: mean
 .. autofunction:: var
 .. autofunction:: std
+.. autofunction:: argmin
+.. autofunction:: argmax
 
 .. autofunction:: all
 .. autofunction:: any

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -118,6 +118,8 @@ Rearranging array contents
 .. autofunction:: dstack
 .. autofunction:: expand_dims
 .. autofunction:: squeeze
+.. autofunction:: split
+.. autofunction:: array_split
 .. autofunction:: reverse
 .. autofunction:: moveaxis
 .. autofunction:: transpose

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -2151,16 +2151,28 @@ def moveaxis(arg: ArrayBase, /, source: Union[int, Tuple[int, ...]], destination
     strides_in = _compute_strides(shape_in)
     strides_out = _compute_strides(shape_out)
 
+    # Smallest moving range [first_axis, last_axis): outside it
+    # order[i] == i and strides agree, so those coords contribute the
+    # same offset to the input and output flat index.
+    first_axis = ndim
     last_axis = 0
     for i, j in enumerate(order):
         if i != j:
+            if i < first_axis:
+                first_axis = i
             last_axis = i + 1
 
     arr = arg.array
     index_out = arange(uint32_array_t(arr), prod(shape_in))
     index_in = 0
 
-    for i in range(last_axis):
+    if first_axis > 0:
+        head_stride = strides_out[first_axis - 1]
+        residue = index_out % head_stride
+        index_in = index_out - residue
+        index_out = residue
+
+    for i in range(first_axis, last_axis):
         pos = index_out // strides_out[i]
         index_out -= pos * strides_out[i]
         index_in += pos * strides_in[order[i]]

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -1823,35 +1823,29 @@ def concat(arr: Sequence[ArrayT], /, axis: Optional[int] = 0) -> ArrayT:
 
     out_shape = list(ref_shape)
     out_shape[axis] = axis_size
-    out_strides = _compute_strides(out_shape)
 
     result = empty(ref_tp, out_shape)
     result_array = result.array
     Index = uint32_array_t(type(result_array))
 
-    axis_size = 0
-    for i, arg in enumerate(arr):
+    out_inner = prod(out_shape[axis:])
+    stride = prod(out_shape[axis + 1:])
+
+    offset = 0
+    for arg in arr:
         arg_shape = arg.shape
-        arg_strides = _compute_strides(arg_shape)
         arg_size = prod(arg_shape)
         arg_array = arg.array
-        index_in = arange(Index, arg_size)
-        index_out = zeros(Index, arg_size)
+        i = arange(Index, arg_size)
 
-        for j in range(ref_ndim):
-            pos_in = index_in // arg_strides[j]
-            pos_out = pos_in
+        if axis == 0:
+            index_out = i + offset * stride
+        else:
+            inner = prod(arg_shape[axis:])
+            index_out = (i // inner) * out_inner + \
+                        (offset * stride) + (i % inner)
 
-            if j == axis:
-                pos_out = pos_out + axis_size
-                axis_size += arg_shape[j]
-
-            index_in -= pos_in * arg_strides[j]
-            index_out += pos_out * out_strides[j]
-
-            if j == axis:
-                index_out += index_in
-                break
+        offset += arg_shape[axis]
 
         scatter(
             target=result_array,

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -1547,6 +1547,163 @@ def std(value, axis = ..., mode = None, keepdims: bool = False, ddof: int = 0):
     return sqrt(var(value, axis=axis, mode=mode, keepdims=keepdims, ddof=ddof))
 
 
+def _to_ordinal_32(value):
+    """Convert an array with <=32-bit elements to order-preserving UInt32."""
+    tp = type(value)
+    vt = type_v(tp)
+    UInt32 = uint32_array_t(tp)
+
+    if vt == VarType.Float16:
+        return _to_ordinal_32(float32_array_t(tp)(value))
+    elif vt == VarType.Float32:
+        u = reinterpret_array(UInt32, value)
+        mask = UInt32(0) - (u >> 31)
+        return u ^ (mask | UInt32(0x80000000))
+    elif is_signed_v(tp):
+        bits = itemsize_v(tp) * 8
+        uint_tp = uint_array_t(tp)
+        u = reinterpret_array(uint_tp, value)
+        return UInt32(u ^ (uint_tp(1) << (bits - 1)))
+    else:
+        return UInt32(value)
+
+
+def _argminmax(value, axis, keepdims, find_max):
+    """
+    Shared implementation of argmin/argmax.
+
+    Uses a packed uint64 reduction for types with <=32-bit elements: the
+    value's order-preserving ordinal occupies the upper 32 bits and the
+    element index the lower 32 bits, so a single min reduction yields both
+    the extremal value and the smallest index among ties.
+
+    Falls back to a two-pass approach (reduce, then find matching index)
+    for 64-bit element types that cannot be packed into 64 bits.
+    """
+    is_tens = is_tensor_v(value)
+
+    if is_tens and axis is None:
+        value = ravel(value)
+        is_tens = False
+
+    tp = type(value)
+    arr = value.array if is_tens else value
+    arr_tp = type(arr)
+    UInt32 = uint32_array_t(arr_tp)
+    UInt64 = uint64_array_t(arr_tp)
+    bits = itemsize_v(arr_tp) * 8
+
+    if is_tens:
+        shape = value.shape
+        ndim = len(shape)
+        if axis < 0:
+            axis += ndim
+        stride = prod(shape[axis + 1:])
+        n = prod(shape)
+        idx = (arange(UInt32, n) // stride) % shape[axis]
+    else:
+        n = len(arr)
+        idx = arange(UInt32, n)
+
+    if bits <= 32:
+        ordinal = _to_ordinal_32(arr)
+        if find_max:
+            ordinal = ~ordinal
+        packed = (UInt64(ordinal) << 32) | UInt64(idx)
+
+        if is_tens:
+            TU64 = tensor_t(UInt64)
+            result = min(TU64(packed, shape), axis=axis, keepdims=keepdims)
+            TU32 = tensor_t(UInt32)
+            return TU32(UInt32(result.array & UInt64(0xFFFFFFFF)), result.shape)
+        else:
+            result = min(packed)
+            return UInt32(result & UInt64(0xFFFFFFFF))
+    else:
+        reduce_fn = max if find_max else min
+        if is_tens:
+            m = reduce_fn(value, axis=axis, keepdims=True)
+            m_arr = m.array
+            m_stride = prod(m.shape[axis + 1:])
+            flat_idx = arange(uint32_array_t(type(m_arr)), n)
+            m_idx = (flat_idx // (stride * shape[axis])) * m_stride + \
+                    (flat_idx % stride)
+            m_expanded = gather(type(m_arr), m_arr, m_idx)
+
+            if find_max:
+                is_ext = arr >= m_expanded
+            else:
+                is_ext = arr <= m_expanded
+
+            idx = select(is_ext, idx, UInt32(0xFFFFFFFF))
+            TU32 = tensor_t(UInt32)
+            return min(TU32(idx, shape), axis=axis, keepdims=keepdims)
+        else:
+            m = reduce_fn(arr)
+            if find_max:
+                is_ext = arr >= m
+            else:
+                is_ext = arr <= m
+            idx = select(is_ext, idx, UInt32(0xFFFFFFFF))
+            return min(idx)
+
+
+def argmin(value, /, axis=None, keepdims: bool = False):
+    """
+    Return the indices of the minimum values along an axis.
+
+    When ``axis`` is ``None``, the index refers to the flattened input. When
+    ``axis`` is an integer, the reduction operates along that axis and the
+    result has the same number of dimensions as the input (minus one, unless
+    ``keepdims`` is ``True``).
+
+    When multiple elements share the minimum value, the smallest index is
+    returned.
+
+    Args:
+        value: Input array or tensor.
+
+        axis (int | None): Axis along which to operate. ``None`` reduces
+            over all elements.
+
+        keepdims (bool): If ``True``, the reduced axis is retained as a
+            length-one dimension.
+
+    Returns:
+        object: An unsigned 32-bit integer array or tensor containing the
+        indices of the minimum values.
+    """
+    return _argminmax(value, axis, keepdims, find_max=False)
+
+
+def argmax(value, /, axis=None, keepdims: bool = False):
+    """
+    Return the indices of the maximum values along an axis.
+
+    When ``axis`` is ``None``, the index refers to the flattened input. When
+    ``axis`` is an integer, the reduction operates along that axis and the
+    result has the same number of dimensions as the input (minus one, unless
+    ``keepdims`` is ``True``).
+
+    When multiple elements share the maximum value, the smallest index is
+    returned.
+
+    Args:
+        value: Input array or tensor.
+
+        axis (int | None): Axis along which to operate. ``None`` reduces
+            over all elements.
+
+        keepdims (bool): If ``True``, the reduced axis is retained as a
+            length-one dimension.
+
+    Returns:
+        object: An unsigned 32-bit integer array or tensor containing the
+        indices of the maximum values.
+    """
+    return _argminmax(value, axis, keepdims, find_max=True)
+
+
 def normalize(arg: T, /) -> T:
     '''
     Normalize the input vector so that it has unit length and return the

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -32,6 +32,7 @@ else:
 from .ast import syntax, hint
 from .interop import wrap
 from . import random
+import builtins as _builtins
 import warnings as _warnings
 
 from functools import wraps
@@ -2085,6 +2086,103 @@ def dstack(arrays: Sequence[ArrayT], /) -> ArrayT:
             a = reshape(tp, a, a.shape + (1,))
         fixed.append(a)
     return concat(fixed, axis=2)
+
+
+def split(value: ArrayT, indices_or_sections: Union[int, Sequence[int]], /,
+          axis: int = 0) -> list:
+    """
+    Split a tensor into multiple parts along an axis.
+
+    When ``indices_or_sections`` is an integer *N*, the tensor is divided into
+    *N* equal parts along ``axis``. The axis size must be divisible by *N*;
+    use :py:func:`array_split` to allow unequal parts.
+
+    When ``indices_or_sections`` is a sequence of indices ``[i, j, ...]``, the
+    splits occur before those positions along the given axis, producing
+    sections ``[:i]``, ``[i:j]``, ``[j:]``, etc.
+
+    Args:
+        value: Input tensor.
+
+        indices_or_sections (int | Sequence[int]): Either the number of
+            equal-sized sections or a sequence of split points.
+
+        axis (int): The axis along which to split. Negative values count
+            backwards from the last dimension.
+
+    Returns:
+        list: A list of tensors.
+    """
+    if not is_tensor_v(value):
+        raise TypeError(
+            f"drjit.split(): expected a tensor input "
+            f"(got {type(value).__module__}.{type(value).__qualname__}).")
+
+    ndim = len(value.shape)
+    if axis < 0:
+        axis += ndim
+
+    n = value.shape[axis]
+    _slice = _builtins.slice
+
+    if isinstance(indices_or_sections, int):
+        if n % indices_or_sections != 0:
+            raise RuntimeError(
+                f"drjit.split(): tensor of size {n} along axis {axis} "
+                f"cannot be equally split into {indices_or_sections} parts. "
+                f"Use drjit.array_split() for unequal splits.")
+        step = n // indices_or_sections
+        indices = range(0, n, step)
+    else:
+        indices = [0] + list(indices_or_sections)
+
+    result = []
+    for i, start in enumerate(indices):
+        end = indices[i + 1] if i + 1 < len(indices) else n
+        s = [_slice(None)] * ndim
+        s[axis] = _slice(start, end)
+        result.append(value[tuple(s)])
+    return result
+
+
+def array_split(value: ArrayT, sections: int, /,
+                axis: int = 0) -> list:
+    """
+    Split a tensor into approximately equal parts along an axis.
+
+    Like :py:func:`split`, but allows the axis size to not be evenly
+    divisible by ``sections``. The first ``n % sections`` chunks have one
+    extra element.
+
+    Args:
+        value: Input tensor.
+
+        sections (int): Number of output sections.
+
+        axis (int): The axis along which to split. Negative values count
+            backwards from the last dimension.
+
+    Returns:
+        list: A list of tensors.
+    """
+    if not is_tensor_v(value):
+        raise TypeError(
+            f"drjit.array_split(): expected a tensor input "
+            f"(got {type(value).__module__}.{type(value).__qualname__}).")
+
+    ndim = len(value.shape)
+    if axis < 0:
+        axis += ndim
+
+    n = value.shape[axis]
+    size, extra = divmod(n, sections)
+    indices = []
+    pos = 0
+    for i in range(sections - 1):
+        pos += size + (1 if i < extra else 0)
+        indices.append(pos)
+
+    return split(value, indices, axis=axis)
 
 
 def squeeze(value: ArrayT, /, axis: Union[int, Tuple[int, ...], None] = None) -> ArrayT:

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -2087,6 +2087,64 @@ def dstack(arrays: Sequence[ArrayT], /) -> ArrayT:
     return concat(fixed, axis=2)
 
 
+def squeeze(value: ArrayT, /, axis: Union[int, Tuple[int, ...], None] = None) -> ArrayT:
+    """
+    Remove length-one axes from a tensor.
+
+    When ``axis`` is ``None`` (the default), all length-one axes are removed.
+    When ``axis`` is an integer or tuple of integers, only those axes are
+    removed, and an error is raised if any of them does not have length one.
+
+    Negative axis values count backwards from the last dimension.
+
+    This is the inverse of :py:func:`expand_dims`.
+
+    Args:
+        value: Input tensor.
+
+        axis (int | tuple[int, ...] | None): The axis or axes to remove.
+            If ``None``, all length-one axes are removed.
+
+    Returns:
+        object: A tensor with the specified length-one dimensions removed.
+    """
+    if not is_tensor_v(value):
+        raise TypeError(
+            f"drjit.squeeze(): expected a tensor input "
+            f"(got {type(value).__module__}.{type(value).__qualname__}).")
+
+    shape = value.shape
+    ndim = len(shape)
+
+    if axis is None:
+        new_shape = tuple(s for s in shape if s != 1)
+    else:
+        if isinstance(axis, int):
+            axis = (axis,)
+
+        normalized = []
+        for a in axis:
+            if a < 0:
+                a += ndim
+            if a < 0 or a >= ndim:
+                raise RuntimeError(
+                    f"drjit.squeeze(): axis {a} is out of bounds "
+                    f"for a {ndim}-dimensional tensor.")
+            if shape[a] != 1:
+                raise RuntimeError(
+                    f"drjit.squeeze(): axis {a} has size {shape[a]}, "
+                    f"not 1.")
+            normalized.append(a)
+
+        if len(set(normalized)) != len(normalized):
+            raise RuntimeError("drjit.squeeze(): duplicate axes are not allowed.")
+
+        new_shape = tuple(s for i, s in enumerate(shape)
+                          if i not in normalized)
+
+    return reshape(type(value), value, new_shape)
+
+
 class _ResampleOp(CustomOp):
     """Implementation detail of the function drjit.resample()"""
     def eval(self, resampler, source, stride):
@@ -2411,6 +2469,89 @@ def moveaxis(arg: ArrayBase, /, source: Union[int, Tuple[int, ...]], destination
     index_in += index_out
 
     return type(arg)(gather(type(arr), arr, index_in, mode=ReduceMode.Permute), shape_out)
+
+
+def transpose(value: ArrayT, /, axes: Optional[Tuple[int, ...]] = None) -> ArrayT:
+    """
+    Permute the axes of a tensor.
+
+    When ``axes`` is ``None``, the axis order is reversed (the default). When
+    ``axes`` is a tuple, it must be a permutation of ``(0, 1, ..., ndim-1)``
+    specifying the new axis order.
+
+    For example, given a tensor of shape ``(2, 3, 4)``:
+
+    - ``transpose(a)`` produces shape ``(4, 3, 2)``
+    - ``transpose(a, (2, 0, 1))`` produces shape ``(4, 2, 3)``
+
+    Args:
+        value: Input tensor.
+
+        axes (tuple[int, ...] | None): The desired axis order. If ``None``,
+            reverses all axes.
+
+    Returns:
+        object: A tensor with permuted axes.
+    """
+    if not is_tensor_v(value):
+        raise TypeError(
+            f"drjit.transpose(): expected a tensor input "
+            f"(got {type(value).__module__}.{type(value).__qualname__}).")
+
+    ndim = len(value.shape)
+    if axes is None:
+        axes = tuple(reversed(range(ndim)))
+    else:
+        axes = tuple(axes)
+        if len(axes) != ndim:
+            raise RuntimeError(
+                f"drjit.transpose(): 'axes' must have length {ndim} "
+                f"(got {len(axes)}).")
+        normalized = []
+        for a in axes:
+            if a < 0:
+                a += ndim
+            if a < 0 or a >= ndim:
+                raise RuntimeError(
+                    f"drjit.transpose(): axis {a} is out of bounds "
+                    f"for a {ndim}-dimensional tensor.")
+            normalized.append(a)
+        if len(set(normalized)) != len(normalized):
+            raise RuntimeError(
+                "drjit.transpose(): 'axes' must be a permutation "
+                f"of (0, 1, ..., {ndim - 1}).")
+        axes = tuple(normalized)
+
+    return moveaxis(value, axes, tuple(range(ndim)))
+
+
+def swapaxes(value: ArrayT, /, axis1: int, axis2: int) -> ArrayT:
+    """
+    Swap two axes of a tensor.
+
+    For example, given a tensor of shape ``(2, 3, 4)``:
+
+    - ``swapaxes(a, 0, 2)`` produces shape ``(4, 3, 2)``
+    - ``swapaxes(a, 0, 1)`` produces shape ``(3, 2, 4)``
+
+    Negative axis values count backwards from the last dimension.
+
+    Args:
+        value: Input tensor.
+
+        axis1 (int): First axis.
+
+        axis2 (int): Second axis.
+
+    Returns:
+        object: A tensor with the two axes exchanged.
+    """
+    if not is_tensor_v(value):
+        raise TypeError(
+            f"drjit.swapaxes(): expected a tensor input "
+            f"(got {type(value).__module__}.{type(value).__qualname__}).")
+
+    return moveaxis(value, (axis1, axis2), (axis2, axis1))
 
 
 def take(value: ArrayT, index: Union[int, ArrayBase], axis: int = 0) -> ArrayT:

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -1856,6 +1856,237 @@ def concat(arr: Sequence[ArrayT], /, axis: Optional[int] = 0) -> ArrayT:
 
     return result
 
+
+def _validate_tensor_sequence(arrays, name: str):
+    if is_array_v(arrays):
+        raise TypeError(f"drjit.{name}(): input should be a Python sequence of tensors, not a single array.")
+    if len(arrays) == 0:
+        raise RuntimeError(f"drjit.{name}(): at least one input tensor is required!")
+    ref_tp = type(arrays[0])
+    if not is_tensor_v(ref_tp):
+        raise TypeError(f"drjit.{name}(): expected tensor inputs (got {ref_tp.__module__}.{ref_tp.__qualname__}).")
+    for i, a in enumerate(arrays):
+        if type(a) is not ref_tp:
+            raise TypeError(f"drjit.{name}(): all inputs must have the same type "
+                            f"(input 0 has type {ref_tp.__module__}.{ref_tp.__qualname__}, "
+                            f"input {i} has type {type(a).__module__}.{type(a).__qualname__}).")
+
+
+def expand_dims(value: ArrayT, /, axis: Union[int, Tuple[int, ...]]) -> ArrayT:
+    """
+    Expand the shape of a tensor by inserting new length-one axes.
+
+    The ``axis`` parameter specifies where new axes are placed in the output
+    shape. For example, given a tensor of shape ``(3, 4)``:
+
+    - ``axis=0`` produces shape ``(1, 3, 4)``
+    - ``axis=1`` produces shape ``(3, 1, 4)``
+    - ``axis=-1`` produces shape ``(3, 4, 1)``
+
+    When ``axis`` is a tuple, multiple axes are inserted simultaneously. The
+    axis positions refer to the output shape, and negative values count
+    backwards from the last output dimension.
+
+    This operation does not copy data; it returns a view of the input with a
+    different shape.
+
+    Args:
+        value: Input tensor.
+
+        axis (int | tuple[int, ...]): Position(s) in the output shape where
+            new length-one axes should be inserted.
+
+    Returns:
+        object: A tensor with the same underlying data and one or more
+        additional length-one dimensions.
+    """
+    if not is_tensor_v(value):
+        raise TypeError(
+            f"drjit.expand_dims(): expected a tensor input "
+            f"(got {type(value).__module__}.{type(value).__qualname__}).")
+
+    shape = value.shape
+    ndim = len(shape)
+
+    if isinstance(axis, int):
+        axis = (axis,)
+
+    out_ndim = ndim + len(axis)
+
+    normalized = []
+    for a in axis:
+        if a < 0:
+            a += out_ndim
+        if a < 0 or a >= out_ndim:
+            raise RuntimeError(
+                f"drjit.expand_dims(): axis {a} is out of bounds "
+                f"for a {out_ndim}-dimensional output.")
+        normalized.append(a)
+
+    if len(set(normalized)) != len(normalized):
+        raise RuntimeError("drjit.expand_dims(): duplicate axes are not allowed.")
+
+    new_shape = list(shape)
+    for a in sorted(normalized):
+        new_shape.insert(a, 1)
+
+    return reshape(type(value), value, new_shape)
+
+
+def stack(arrays: Sequence[ArrayT], /, axis: int = 0) -> ArrayT:
+    """
+    Join a sequence of tensors along a new axis.
+
+    All input tensors must have the same type and shape. The result has one
+    more dimension than the inputs: a new axis of size ``len(arrays)`` is
+    inserted at position ``axis``.
+
+    For example, stacking two tensors of shape ``(M, N)`` with ``axis=0``
+    produces shape ``(2, M, N)``, while ``axis=1`` produces ``(M, 2, N)``.
+
+    Unlike :py:func:`concat`, which joins arrays along an *existing* axis,
+    ``stack`` always creates a *new* one.
+
+    Args:
+        arrays: Sequence of tensors. All must have the same type and shape.
+
+        axis (int): The position of the new axis in the result. Negative
+            values count backwards from the last dimension.
+
+    Returns:
+        object: A tensor with ``ndim + 1`` dimensions.
+    """
+    _validate_tensor_sequence(arrays, 'stack')
+
+    ref_shape = arrays[0].shape
+    ndim = len(ref_shape)
+
+    for i, a in enumerate(arrays):
+        if a.shape != ref_shape:
+            raise TypeError(
+                f"drjit.stack(): all inputs must have the same shape "
+                f"(input 0 has shape {ref_shape}, "
+                f"input {i} has shape {a.shape}).")
+
+    if axis < 0:
+        axis += ndim + 1
+    if axis < 0 or axis > ndim:
+        raise RuntimeError(
+            f"drjit.stack(): axis {axis} is out of bounds "
+            f"for tensors with {ndim} dimensions.")
+
+    expanded = [expand_dims(a, axis=axis) for a in arrays]
+    return concat(expanded, axis=axis)
+
+
+def vstack(arrays: Sequence[ArrayT], /) -> ArrayT:
+    """
+    Stack tensors vertically (row-wise).
+
+    Concatenates tensors along the first axis. 1D tensors of shape ``(N,)``
+    are first reshaped to ``(1, N)`` so that they become rows. The result is
+    always at least 2D.
+
+    The inputs must have the same shape along all but the first axis.
+
+    ``row_stack`` is an alias for this function.
+
+    Args:
+        arrays: Sequence of tensors to stack.
+
+    Returns:
+        object: A tensor with at least two dimensions formed by vertical
+        concatenation.
+    """
+    _validate_tensor_sequence(arrays, 'vstack')
+    tp = type(arrays[0])
+    fixed = [reshape(tp, a, (1,) + a.shape) if len(a.shape) == 1
+             else a for a in arrays]
+    return concat(fixed, axis=0)
+
+
+row_stack = vstack
+
+
+def hstack(arrays: Sequence[ArrayT], /) -> ArrayT:
+    """
+    Stack tensors horizontally (column-wise).
+
+    For tensors with two or more dimensions, this concatenates along the
+    second axis. For 1D tensors, it concatenates along the first (and only)
+    axis.
+
+    The inputs must have the same shape along all but the concatenation axis.
+
+    Args:
+        arrays: Sequence of tensors to stack.
+
+    Returns:
+        object: A tensor formed by horizontal concatenation.
+    """
+    _validate_tensor_sequence(arrays, 'hstack')
+    if len(arrays[0].shape) == 1:
+        return concat(arrays, axis=0)
+    return concat(arrays, axis=1)
+
+
+def column_stack(arrays: Sequence[ArrayT], /) -> ArrayT:
+    """
+    Stack 1D tensors as columns into a 2D tensor.
+
+    Takes a sequence of 1D tensors and stacks them as columns to produce a
+    2D result. Each 1D tensor of shape ``(N,)`` is first reshaped to
+    ``(N, 1)``, then all inputs are concatenated along axis 1.
+
+    2D (or higher) tensors are concatenated along axis 1 as-is, like
+    :py:func:`hstack`.
+
+    All inputs must have the same first dimension.
+
+    Args:
+        arrays: Sequence of tensors to stack.
+
+    Returns:
+        object: A tensor formed by column-wise concatenation.
+    """
+    _validate_tensor_sequence(arrays, 'column_stack')
+    tp = type(arrays[0])
+    fixed = [reshape(tp, a, a.shape + (1,)) if len(a.shape) == 1
+             else a for a in arrays]
+    return concat(fixed, axis=1)
+
+
+def dstack(arrays: Sequence[ArrayT], /) -> ArrayT:
+    """
+    Stack tensors depth-wise (along the third axis).
+
+    Concatenates tensors along the third axis after reshaping them to at least
+    3D. 1D tensors of shape ``(N,)`` become ``(1, N, 1)`` and 2D tensors of
+    shape ``(M, N)`` become ``(M, N, 1)`` before concatenation. The result is
+    always at least 3D.
+
+    The inputs must have the same shape along all but the third axis.
+
+    Args:
+        arrays: Sequence of tensors to stack.
+
+    Returns:
+        object: A tensor with at least three dimensions formed by depth-wise
+        concatenation.
+    """
+    _validate_tensor_sequence(arrays, 'dstack')
+    tp = type(arrays[0])
+    fixed = []
+    for a in arrays:
+        ndim = len(a.shape)
+        if ndim == 1:
+            a = reshape(tp, a, (1,) + a.shape + (1,))
+        elif ndim == 2:
+            a = reshape(tp, a, a.shape + (1,))
+        fixed.append(a)
+    return concat(fixed, axis=2)
+
+
 class _ResampleOp(CustomOp):
     """Implementation detail of the function drjit.resample()"""
     def eval(self, resampler, source, stride):

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -1568,6 +1568,64 @@ def _to_ordinal_32(value):
         return UInt32(value)
 
 
+def _to_ordinal_64(value):
+    """Convert an array with 64-bit elements to order-preserving UInt64."""
+    tp = type(value)
+    vt = type_v(tp)
+    UInt64 = uint64_array_t(tp)
+
+    if vt == VarType.Float64:
+        u = reinterpret_array(UInt64, value)
+        mask = UInt64(0) - (u >> 63)
+        return u ^ (mask | UInt64(0x8000000000000000))
+    elif is_signed_v(tp):
+        uint_tp = uint_array_t(tp)
+        u = reinterpret_array(uint_tp, value)
+        return UInt64(u ^ (uint_tp(1) << 63))
+    else:
+        return UInt64(value)
+
+
+def _from_ordinal_32(ordinal, target_tp):
+    """Invert _to_ordinal_32: convert order-preserving UInt32 back to the original type."""
+    vt = type_v(target_tp)
+    UInt32 = type(ordinal)
+
+    if vt == VarType.Float16:
+        f32_tp = float32_array_t(target_tp)
+        return target_tp(_from_ordinal_32(ordinal, f32_tp))
+    elif vt == VarType.Float32:
+        sign = 1 - (ordinal >> 31)
+        mask = UInt32(0) - sign
+        u = ordinal ^ (mask | UInt32(0x80000000))
+        return reinterpret_array(target_tp, u)
+    elif is_signed_v(target_tp):
+        bits = itemsize_v(target_tp) * 8
+        uint_tp = uint_array_t(target_tp)
+        u = uint_tp(ordinal) ^ (uint_tp(1) << (bits - 1))
+        return reinterpret_array(target_tp, u)
+    else:
+        return target_tp(ordinal)
+
+
+def _from_ordinal_64(ordinal, target_tp):
+    """Invert _to_ordinal_64: convert order-preserving UInt64 back to the original type."""
+    vt = type_v(target_tp)
+    UInt64 = type(ordinal)
+
+    if vt == VarType.Float64:
+        sign = 1 - (ordinal >> 63)
+        mask = UInt64(0) - sign
+        u = ordinal ^ (mask | UInt64(0x8000000000000000))
+        return reinterpret_array(target_tp, u)
+    elif is_signed_v(target_tp):
+        uint_tp = uint_array_t(target_tp)
+        u = uint_tp(ordinal) ^ (uint_tp(1) << 63)
+        return reinterpret_array(target_tp, u)
+    else:
+        return target_tp(ordinal)
+
+
 def _argminmax(value, axis, keepdims, find_max):
     """
     Shared implementation of argmin/argmax.
@@ -1702,6 +1760,152 @@ def argmax(value, /, axis=None, keepdims: bool = False):
         indices of the maximum values.
     """
     return _argminmax(value, axis, keepdims, find_max=True)
+
+
+def _radix_sort(arr, block_size, descending, return_indices):
+    """
+    Multi-pass radix sort using block_mkperm.
+
+    Operates on the flat inner array. When block_size < len(arr),
+    independently sorts contiguous groups of block_size elements.
+    """
+    arr_tp = type(arr)
+    bits = itemsize_v(arr_tp) * 8
+    n = len(arr)
+
+    if n <= 1 or block_size <= 1:
+        if return_indices:
+            UInt32 = uint32_array_t(arr_tp)
+            return arange(UInt32, n)
+        else:
+            return arr_tp(arr)
+
+    if bits <= 32:
+        ordinal = _to_ordinal_32(arr)
+    else:
+        ordinal = _to_ordinal_64(arr)
+
+    if descending:
+        ordinal = ~ordinal
+
+    Ordinal = type(ordinal)
+    ordinal_bits = itemsize_v(Ordinal) * 8
+    UInt32 = uint32_array_t(arr_tp)
+
+    # 11-bit radix (3 passes for 32-bit) is faster on CPU; 8-bit radix
+    # (4 passes) is better on GPU where shared memory is limited.
+    radix_bits = 11 if backend_v(arr_tp) == JitBackend.LLVM else 8
+
+    if return_indices:
+        index = arange(UInt32, n)
+
+    shift = 0
+    bits_remaining = ordinal_bits
+    while bits_remaining > 0:
+        bits_this_pass = min(radix_bits, bits_remaining)
+        bucket_count = 1 << bits_this_pass
+        mask = bucket_count - 1
+
+        digit = UInt32((ordinal >> shift) & Ordinal(mask))
+
+        eval(digit, ordinal)
+        perm = detail.block_mkperm(digit, block_size, bucket_count)
+
+        ordinal = gather(Ordinal, ordinal, perm)
+        if return_indices:
+            index = gather(UInt32, index, perm)
+
+        shift += bits_this_pass
+        bits_remaining -= bits_this_pass
+
+    if return_indices:
+        return index
+    else:
+        if descending:
+            ordinal = ~ordinal
+        if bits <= 32:
+            return _from_ordinal_32(ordinal, arr_tp)
+        else:
+            return _from_ordinal_64(ordinal, arr_tp)
+
+
+def _sort_tensor_prep(value, axis):
+    """Normalize axis and rotate the target axis to the last position."""
+    shape = value.shape
+    ndim = len(shape)
+    if axis < 0:
+        axis += ndim
+    if axis != ndim - 1:
+        value = moveaxis(value, axis, -1)
+    return value, value.shape, axis
+
+
+def sort(value, /, axis=-1, descending=False):
+    '''
+    Sort the elements of an array or tensor.
+
+    For 1D arrays, returns a sorted copy. For tensors, sorts along the
+    specified axis (default: last axis). The sort is stable: elements with
+    equal values preserve their original relative order.
+
+    Uses a multi-pass radix sort internally (3 passes for 32-bit types on
+    CPU, 4 on GPU).
+
+    Args:
+        value: Input array or tensor.
+
+        axis (int): Axis along which to sort. Only ``-1`` (last axis) and
+            ``0`` are currently supported for tensors.
+
+        descending (bool): If ``True``, sort in descending order.
+
+    Returns:
+        object: A sorted copy of the input with the same type and shape.
+    '''
+    if is_tensor_v(value):
+        value, shape, axis = _sort_tensor_prep(value, axis)
+        result = type(value)(
+            _radix_sort(value.array, shape[-1], descending, return_indices=False), shape)
+        if axis != len(shape) - 1:
+            result = moveaxis(result, -1, axis)
+        return result
+    else:
+        return _radix_sort(value, len(value), descending, return_indices=False)
+
+
+def argsort(value, /, axis=-1, descending=False):
+    '''
+    Return the indices that would sort an array or tensor.
+
+    For 1D arrays, returns index array such that ``dr.gather(type(value),
+    value, result)`` is sorted. For tensors, returns indices along the
+    specified axis.
+
+    The sort is stable: among equal elements, the original index order
+    is preserved.
+
+    Args:
+        value: Input array or tensor.
+
+        axis (int): Axis along which to sort. Only ``-1`` (last axis) and
+            ``0`` are currently supported for tensors.
+
+        descending (bool): If ``True``, sort in descending order.
+
+    Returns:
+        object: An unsigned 32-bit integer array or tensor containing the
+        sorting indices.
+    '''
+    if is_tensor_v(value):
+        value, shape, axis = _sort_tensor_prep(value, axis)
+        UInt32 = uint32_array_t(type(value.array))
+        raw = _radix_sort(value.array, shape[-1], descending, return_indices=True)
+        result = tensor_t(UInt32)(raw % shape[-1], shape)
+        if axis != len(shape) - 1:
+            result = moveaxis(result, -1, axis)
+        return result
+    else:
+        return _radix_sort(value, len(value), descending, return_indices=True)
 
 
 def normalize(arg: T, /) -> T:

--- a/src/python/detail.cpp
+++ b/src/python/detail.cpp
@@ -473,6 +473,48 @@ void export_detail(nb::module_ &) {
     d.def("traverse_py_cb_rw", &traverse_py_cb_rw_impl);
     d.def("freeze_discard", jit_freeze_discard);
 
+    d.def("block_mkperm",
+          [](nb::handle_t<dr::ArrayBase> values, uint32_t block_size,
+             uint32_t bucket_count) -> nb::object {
+              const ArraySupplement &s = supp(values.type());
+              if (s.type != (uint16_t) VarType::UInt32 || s.ndim != 1 ||
+                  (JitBackend) s.backend == JitBackend::None)
+                  nb::raise("drjit.detail.block_mkperm(): 'values' must be "
+                            "a flat JIT-compiled UInt32 array.");
+
+              uint32_t idx = (uint32_t) s.index(inst_ptr(values));
+              jit_var_eval(idx);
+
+              void *data_ptr = nullptr;
+              uint32_t data_idx = jit_var_data(idx, &data_ptr);
+              uint32_t size = (uint32_t) jit_var_size(idx);
+
+              JitBackend backend = (JitBackend) s.backend;
+              AllocType at = (backend == JitBackend::CUDA)
+                  ? AllocType::Device : AllocType::HostAsync;
+              uint32_t *perm = (uint32_t *) jit_malloc(at,
+                  (size_t) size * sizeof(uint32_t));
+
+              jit_block_mkperm(backend, (const uint32_t *) data_ptr,
+                                 size, block_size, bucket_count,
+                                 perm, nullptr);
+
+              jit_var_dec_ref(data_idx);
+
+              uint32_t perm_idx = jit_var_mem_map(backend, VarType::UInt32,
+                                                  perm, size, 1);
+
+              ArrayMeta m = s;
+              nb::handle tp = meta_get_type(m);
+              nb::object result = nb::inst_alloc(tp);
+              s.init_index(perm_idx, inst_ptr(result));
+              jit_var_dec_ref(perm_idx);
+              nb::inst_mark_ready(result);
+              return result;
+          },
+          "values"_a, "block_size"_a, "bucket_count"_a, doc_block_mkperm,
+          nb::sig("def block_mkperm(values: drjit.llvm.UInt32 | drjit.cuda.UInt32, block_size: int, bucket_count: int) -> drjit.llvm.UInt32 | drjit.cuda.UInt32"));
+
     nb::enum_<AllocType>(d, "AllocType")
         .value("Host", AllocType::Host)
         .value("HostAsync", AllocType::HostAsync)

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -1384,6 +1384,62 @@
     Returns:
         The block-reduced array or PyTree as specified above.
 
+.. topic:: block_mkperm
+
+    Compute a stable permutation that groups elements by bucket, independently
+    within each contiguous block of ``block_size`` elements.
+
+    Given a flat :py:class:`drjit.llvm.UInt32` or :py:class:`drjit.cuda.UInt32`
+    array ``values`` whose entries are bucket indices in the range
+    ``[0, bucket_count)``, this function returns a permutation array ``perm``
+    of the same size and type such that gathering ``values`` through ``perm``
+    yields elements in non-decreasing bucket order. Elements with the same
+    bucket value keep their original relative order (stable sort).
+
+    When ``block_size < len(values)``, the array is treated as a sequence of
+    contiguous blocks of ``block_size`` elements that are sorted independently.
+    Set ``block_size = len(values)`` to sort the entire array as a single block.
+
+    .. note::
+
+       This is a low-level primitive primarily meant for internal use.
+       It underlies several higher-level Dr.Jit operations:
+
+       - :py:func:`drjit.sort` and :py:func:`drjit.argsort`: each radix pass
+         extracts one digit into a ``UInt32`` array and calls ``block_mkperm``
+         to produce the pass permutation.
+
+       - :py:func:`drjit.switch` and :py:func:`drjit.dispatch` in evaluated
+         mode: the callable index array is bucketed by ``block_mkperm`` so that
+         each callable receives a contiguous slice of the work items.
+
+    **Example.** Two blocks of 3, three buckets:
+
+    .. code-block:: python
+
+        digits = jit.UInt32([2, 0, 1,  0, 1, 2])
+        perm   = dr.detail.block_mkperm(digits, block_size=3, bucket_count=3)
+        # perm                           == [1, 2, 0,  3, 4, 5]
+        # dr.gather(jit.UInt32, digits, perm) == [0, 1, 2,  0, 1, 2]
+
+    Block 0 (``[2, 0, 1]``) is reordered to ``[0, 1, 2]`` via local indices
+    ``[1, 2, 0]``; block 1 (``[0, 1, 2]``) is already sorted so its global
+    indices ``[3, 4, 5]`` are unchanged.
+
+    Args:
+        values (drjit.llvm.UInt32 | drjit.cuda.UInt32): Flat 1-D integer
+          array of bucket indices. Every element must satisfy
+          ``0 <= values[i] < bucket_count``.
+
+        block_size (int): Number of elements per independent sorting block.
+
+        bucket_count (int): Number of distinct buckets. Must be a power of two
+          and match the range of ``values``.
+
+    Returns:
+        drjit.llvm.UInt32 | drjit.cuda.UInt32: Permutation index array of the
+        same size as ``values``.
+
 .. topic:: sqrt
 
     Evaluate the square root of the provided input.

--- a/src/python/slice.cpp
+++ b/src/python/slice.cpp
@@ -172,41 +172,97 @@ slice_index(const nb::type_object_t<ArrayBase> &dtype,
         size_out *= size;
     }
 
-    nb::object index = arange(dtype, 0, size_out, 1),
-               index_out;
+    if (size_out == 0)
+        return { nb::tuple(shape_out), dtype() };
 
+    // A "passthrough" axis is a full `:` slice over a dim of its full
+    // input size, e.g. axes 1 and 2 in `t[a, :, :]`. Such an axis is the
+    // identity: its input and output strides agree, so within a run of
+    // passthrough axes a slab of the linear output index maps directly
+    // to the input. Coalesce each run into one synthetic axis so the
+    // main loop below handles it as one ordinary iteration.
+    auto is_passthrough = [](const Component &c) {
+        return !c.object.is_valid() && c.start == 0 && c.step == 1 &&
+               c.slice_size == c.size;
+    };
+    {
+        size_t out = 0;
+        for (size_t k = 0; k < components.size();) {
+            if (!is_passthrough(components[k])) {
+                if (out != k)
+                    components[out] = std::move(components[k]);
+                ++out; ++k;
+                continue;
+            }
+            size_t run_size = 1;
+            while (k < components.size() && is_passthrough(components[k]))
+                run_size *= components[k++].size;
+            components[out++] = Component(0, 1, (Py_ssize_t) run_size,
+                                          (Py_ssize_t) run_size);
+        }
+        components.erase(components.begin() + out, components.end());
+    }
+
+    // A "skippable" axis has output size 1 *and* a fixed input position,
+    // so its contribution is a single constant we fold into `base`. Two
+    // forms qualify: a literal integer index `t[i]`, and a `:` slice on
+    // a size-1 input dim. (An index-array `t[arr]` with len(arr) == 1
+    // also has output size 1, but reads `arr[0]` at runtime, so it
+    // requires a gather and is NOT skippable.)
+    auto is_skippable = [](const Component &c) {
+        return !c.object.is_valid() && c.slice_size == 1;
+    };
+
+    // Walk `components` once to compute:
+    //   `base`  -- the total constant input offset, summing
+    //              `start * input_stride` over every non-gather axis.
+    //              Seeded into `index_out` so the main loop's per-axis
+    //              fma absorbs it for free (one fewer add per axis).
+    //   `first` -- index of the outermost non-skippable axis. The main
+    //              loop terminates there: at that point `index` already
+    //              holds the axis's output coordinate, so no further
+    //              divmod is needed.
+    uint32_t base = 0;
+    size_t in_stride = 1, first = components.size();
+    for (size_t k = components.size(); k-- > 0;) {
+        const Component &c = components[k];
+        if (!c.object.is_valid())
+            base += uint32_t(c.start * in_stride);
+        if (!is_skippable(c))
+            first = k;
+        in_stride *= c.size;
+    }
+
+    nb::object index = arange(dtype, 0, size_out, 1);
     nb::object active = nb::borrow(Py_True);
-    if (size_out) {
-        size_out = 1;
-        index_out = dtype(0);
+    nb::object index_out = dtype(base);
 
-        for (auto it = components.rbegin(); it != components.rend(); ++it) {
-            const Component &c = *it;
-            nb::object index_next, index_rem;
-
-            if (it + 1 != components.rend()) {
-                index_next = index.floor_div(dtype(c.slice_size));
-                index_rem = fma(index_next, dtype(uint32_t(-c.slice_size)), index);
+    // Process axes from innermost to outermost, peeling one output
+    // coordinate off `index` at each step.
+    in_stride = 1;
+    for (size_t k = components.size(); k-- > first;) {
+        const Component &c = components[k];
+        if (!is_skippable(c)) {
+            nb::object rem;
+            if (k == first) {
+                rem = std::move(index);
             } else {
-                index_rem = index;
+                nb::object next = index.floor_div(dtype(c.slice_size));
+                rem = fma(next, dtype(uint32_t(-c.slice_size)), index);
+                index = std::move(next);
             }
 
-            nb::object index_val;
-            if (!c.object.is_valid())
-                index_val = fma(index_rem, dtype(uint32_t(c.step * size_out)),
-                                dtype(uint32_t(c.start * size_out)));
+            // Add this axis's contribution to the input linear index:
+            //   slice:  (step * rem) * in_stride   (start * in_stride is in `base`)
+            //   gather: arr[rem]    * in_stride
+            uint32_t coef = uint32_t(in_stride);
+            if (c.object.is_valid())
+                rem = gather(dtype, c.object, rem, active, ReduceMode::Auto);
             else
-                index_val = gather(dtype, c.object, index_rem, active,
-                                   ReduceMode::Auto) *
-                            dtype(uint32_t(size_out));
-
-            index_out += index_val;
-
-            index = std::move(index_next);
-            size_out *= c.size;
+                coef *= uint32_t(c.step);
+            index_out = fma(rem, dtype(coef), index_out);
         }
-    } else {
-        index_out = dtype();
+        in_stride *= c.size;
     }
 
     return { nb::tuple(shape_out), index_out };

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -641,3 +641,119 @@ def test23_argmin_argmax_tensor(t):
     r_np = np.argmin(v_np, axis=1, keepdims=True)
     assert r.shape == r_np.shape
     assert np.array_equal(r.numpy(), r_np)
+
+
+@pytest.test_arrays('jit, float32, shape=(*)')
+def test24_sort_argsort_1d(t):
+    np = pytest.importorskip("numpy")
+
+    def check(arr_t, x_np):
+        x_dr = arr_t(x_np)
+        s_np = np.sort(x_np, kind='stable')
+        assert np.array_equal(dr.sort(x_dr).numpy(), s_np)
+        assert np.array_equal(dr.sort(x_dr, descending=True).numpy(), s_np[::-1])
+        idx = dr.argsort(x_dr)
+        assert np.array_equal(dr.gather(arr_t, x_dr, idx).numpy(), s_np)
+        idx_d = dr.argsort(x_dr, descending=True)
+        assert np.array_equal(dr.gather(arr_t, x_dr, idx_d).numpy(), s_np[::-1])
+
+    f32 = t
+    f16 = dr.float16_array_t(t)
+    f64 = dr.float64_array_t(t)
+    i32 = dr.int32_array_t(t)
+    u32 = dr.uint32_array_t(t)
+    i64 = dr.int64_array_t(t)
+    u64 = dr.uint64_array_t(t)
+
+    check(f32, np.array([42.0], dtype=np.float32))              # n=1
+    check(f32, np.array([2.0, 1.0], dtype=np.float32))          # n=2, must swap
+    check(f32, np.array([1.0, 1.0, 1.0], dtype=np.float32))     # all equal
+    check(f32, np.array([3, 1, 4, 1, 5, 9, 2, 6], dtype=np.float32))
+    check(f32, np.array([-3.5, 1.0, -0.5, 2.0, 0.0], dtype=np.float32))
+
+    check(f16, np.array([3, 1, 4, 1, 5, 9], dtype=np.float16))
+    check(f16, np.array([-1.5, 0.5, -0.5, 2.0], dtype=np.float16))
+
+    check(f64, np.array([3.0, 1.0, 4.0, 1.0, 5.0], dtype=np.float64))
+    check(f64, np.array([-1e300, 1e300, 0.0, -1.0], dtype=np.float64))
+
+    check(i32, np.array([-5, 3, -8, 1, 0], dtype=np.int32))
+    check(i32, np.array([-(2**31), 2**31 - 1, 0], dtype=np.int32))   # int32 boundary
+
+    check(u32, np.array([5, 3, 8, 1, 7], dtype=np.uint32))
+    check(u32, np.array([2**32 - 1, 0, 2**16, 1], dtype=np.uint32))  # uint32 boundary
+
+    check(i64, np.array([-5, 3, -8, 1, 0], dtype=np.int64))
+    check(i64, np.array([-(2**63), 2**63 - 1, 0], dtype=np.int64))   # int64 boundary
+
+    check(u64, np.array([5, 3, 8, 1, 7], dtype=np.uint64))
+    check(u64, np.array([2**64 - 1, 0, 2**32, 1], dtype=np.uint64))  # uint64 boundary
+
+
+@pytest.test_arrays('is_tensor, jit, float32')
+def test25_sort_argsort_tensor(t):
+    np = pytest.importorskip("numpy")
+    rng = np.random.default_rng(42)
+
+    def check_tensor(shape, axis):
+        x_np = rng.integers(0, 100, size=shape).astype(np.float32)
+        x_dr = t(x_np)
+        s_np = np.sort(x_np, axis=axis, kind='stable')
+
+        # ascending sort: shape and values must match
+        s_dr = dr.sort(x_dr, axis=axis)
+        assert s_dr.shape == s_np.shape, f'shape mismatch shape={shape} axis={axis}'
+        assert np.array_equal(s_dr.numpy(), s_np), f'sort mismatch shape={shape} axis={axis}'
+
+        # descending sort
+        s_np_d = np.flip(s_np, axis=axis)
+        assert np.array_equal(dr.sort(x_dr, axis=axis, descending=True).numpy(), s_np_d), \
+            f'descending sort mismatch shape={shape} axis={axis}'
+
+        # argsort ascending: np.take_along_axis must reproduce the sorted values
+        idx_np = dr.argsort(x_dr, axis=axis).numpy()
+        assert np.array_equal(np.take_along_axis(x_np, idx_np, axis=axis), s_np), \
+            f'argsort mismatch shape={shape} axis={axis}'
+
+        # argsort descending
+        idx_np_d = dr.argsort(x_dr, axis=axis, descending=True).numpy()
+        assert np.array_equal(np.take_along_axis(x_np, idx_np_d, axis=axis), s_np_d), \
+            f'argsort descending mismatch shape={shape} axis={axis}'
+
+    for shape, axis in [
+        # 2D: standard shapes
+        ((4, 6),  0), ((4, 6),  1), ((4, 6), -1),
+        # 2D: prime dimensions
+        ((7, 11), 0), ((7, 11), 1),
+        ((13, 5), 0), ((13, 5), 1),
+        # 2D: degenerate (single row/column)
+        ((1, 10), 0), ((1, 10), 1),
+        ((10, 1), 0), ((10, 1), 1),
+        # 3D: standard shapes and all axes
+        ((3, 4, 5), 0), ((3, 4, 5), 1), ((3, 4, 5), 2), ((3, 4, 5), -1),
+        # 3D: prime last dimension
+        ((2, 3, 7), 0), ((2, 3, 7), 1), ((2, 3, 7), 2),
+        # 3D: prime middle dimension
+        ((2, 7, 3), 0), ((2, 7, 3), 1), ((2, 7, 3), 2),
+    ]:
+        check_tensor(shape, axis)
+
+
+@pytest.test_arrays('jit, float32, shape=(*)')
+def test26_sort_stress(t):
+    np = pytest.importorskip("numpy")
+    rng = np.random.default_rng(0)
+    u64 = dr.uint64_array_t(t)
+
+    for n in [97, 512, 2049, 10007, 100003]:
+        # 32-bit path (Float32)
+        x32 = rng.random(n).astype(np.float32)
+        assert np.array_equal(dr.sort(t(x32)).numpy(), np.sort(x32)), \
+            f'float32 stress sort failed n={n}'
+
+        # 64-bit path (UInt64, values spanning full 64 bits)
+        lo = rng.integers(0, 2**32, size=n, dtype=np.uint64)
+        hi = rng.integers(0, 2**32, size=n, dtype=np.uint64)
+        x64 = (hi << 32) | lo
+        assert np.array_equal(dr.sort(u64(x64)).numpy(), np.sort(x64)), \
+            f'uint64 stress sort failed n={n}'

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -580,3 +580,64 @@ def test21_clip(t):
 
     a = dr.clip(t([1, 2, 3]), 0, 2)
     assert dr.allclose(a, [1, 2, 2])
+
+
+@pytest.test_arrays('jit, float32, shape=(*)')
+def test22_argmin_argmax_1d(t):
+    np = pytest.importorskip("numpy")
+
+    for vals in [[3, 1, 4, 1, 5, 9, 2, 6], [-3, -1, -4, -1, 5],
+                 [1, 0, 0, 1], [42]]:
+        a_np = np.array(vals, dtype=np.float32)
+        assert dr.argmin(t(vals))[0] == np.argmin(a_np)
+        assert dr.argmax(t(vals))[0] == np.argmax(a_np)
+
+    # signed integer path
+    i32 = dr.int32_array_t(t)
+    a_np = np.array([-5, 3, -8, 1, 0], dtype=np.int32)
+    assert dr.argmin(i32(-5, 3, -8, 1, 0))[0] == np.argmin(a_np)
+    assert dr.argmax(i32(-5, 3, -8, 1, 0))[0] == np.argmax(a_np)
+
+    # unsigned integer path
+    u32 = dr.uint32_array_t(t)
+    a_np = np.array([5, 3, 8, 1, 7], dtype=np.uint32)
+    assert dr.argmin(u32(5, 3, 8, 1, 7))[0] == np.argmin(a_np)
+    assert dr.argmax(u32(5, 3, 8, 1, 7))[0] == np.argmax(a_np)
+
+
+@pytest.test_arrays('is_tensor, jit, float')
+def test23_argmin_argmax_tensor(t):
+    np = pytest.importorskip("numpy")
+    ta = dr.array_t(t)
+    np_dtype = np.float32 if dr.itemsize_v(ta) <= 4 else np.float64
+
+    # 2D
+    v = t(ta(3, 1, 4, 1, 5, 9), (2, 3))
+    v_np = np.array([[3, 1, 4], [1, 5, 9]], dtype=np_dtype)
+    for axis in [0, 1, -1, None]:
+        r_dr = dr.argmin(v, axis=axis)
+        r_np = np.argmin(v_np, axis=axis)
+        if axis is None:
+            assert r_dr[0] == r_np
+        else:
+            assert np.array_equal(r_dr.numpy(), r_np)
+
+        r_dr = dr.argmax(v, axis=axis)
+        r_np = np.argmax(v_np, axis=axis)
+        if axis is None:
+            assert r_dr[0] == r_np
+        else:
+            assert np.array_equal(r_dr.numpy(), r_np)
+
+    # 3D
+    v3 = t(dr.arange(ta, 24) * ta(7) - ta(40), (2, 3, 4))
+    v3_np = (np.arange(24) * 7 - 40).astype(np_dtype).reshape(2, 3, 4)
+    for axis in [0, 1, 2]:
+        assert np.array_equal(dr.argmin(v3, axis=axis).numpy(), np.argmin(v3_np, axis=axis))
+        assert np.array_equal(dr.argmax(v3, axis=axis).numpy(), np.argmax(v3_np, axis=axis))
+
+    # keepdims
+    r = dr.argmin(v, axis=1, keepdims=True)
+    r_np = np.argmin(v_np, axis=1, keepdims=True)
+    assert r.shape == r_np.shape
+    assert np.array_equal(r.numpy(), r_np)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1067,3 +1067,60 @@ def test36_swapaxes(t):
 
     with pytest.raises(TypeError, match="expected a tensor"):
         dr.swapaxes(dr.array_t(t)(1, 2, 3), 0, 1)
+
+
+@pytest.test_arrays('is_tensor, jit, uint32')
+def test37_split(t):
+    np = pytest.importorskip("numpy")
+
+    def check_split(dr_parts, np_parts):
+        assert len(dr_parts) == len(np_parts)
+        for d, n in zip(dr_parts, np_parts):
+            assert d.shape == n.shape
+            assert np.allclose(d.numpy(), n)
+
+    # equal split by count
+    configs_equal = [
+        ((12,),     4,    0),
+        ((3, 4),    3,    0),
+        ((3, 4),    2,    1),
+        ((3, 4),    2,   -1),
+        ((2, 3, 4), 2,    0),
+        ((2, 3, 4), 3,    1),
+        ((2, 3, 4), 4,    2),
+    ]
+    for shape, sections, axis in configs_equal:
+        size = dr.prod(shape)
+        v_dr = t(dr.arange(dr.array_t(t), size), shape)
+        v_np = np.arange(size).reshape(shape)
+        check_split(dr.split(v_dr, sections, axis=axis),
+                     np.split(v_np, sections, axis=axis))
+
+    # split by index list
+    configs_indices = [
+        ((10,),     [3, 7],    0),
+        ((3, 6),    [1, 4],    1),
+        ((2, 6, 4), [2, 5],    1),
+    ]
+    for shape, indices, axis in configs_indices:
+        size = dr.prod(shape)
+        v_dr = t(dr.arange(dr.array_t(t), size), shape)
+        v_np = np.arange(size).reshape(shape)
+        check_split(dr.split(v_dr, indices, axis=axis),
+                     np.split(v_np, indices, axis=axis))
+
+    # array_split (unequal)
+    for n, sections in [(10, 3), (7, 3), (11, 4)]:
+        v_dr = t(dr.arange(dr.array_t(t), n), (n,))
+        v_np = np.arange(n)
+        check_split(dr.array_split(v_dr, sections),
+                     np.array_split(v_np, sections))
+
+    # error cases
+    v = t(dr.arange(dr.array_t(t), 10), (10,))
+    with pytest.raises(RuntimeError, match="cannot be equally split"):
+        dr.split(v, 3)
+    with pytest.raises(TypeError, match="expected a tensor"):
+        dr.split(dr.array_t(t)(1, 2, 3), 3)
+    with pytest.raises(TypeError, match="expected a tensor"):
+        dr.array_split(dr.array_t(t)(1, 2, 3), 3)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -955,3 +955,115 @@ def test33_vstack_hstack_column_stack_dstack(t):
         with pytest.raises(TypeError, match="expected tensor"):
             fn([a, a])
 
+
+@pytest.test_arrays('is_tensor, jit, uint32')
+def test34_squeeze(t):
+    np = pytest.importorskip("numpy")
+
+    configs = [
+        ((1, 2, 1, 3, 1), None),
+        ((1, 2, 1, 3, 1), 0),
+        ((1, 2, 1, 3, 1), 2),
+        ((1, 2, 1, 3, 1), -1),
+        ((1, 2, 1, 3, 1), (0, 2)),
+        ((1, 2, 1, 3, 1), (0, 2, 4)),
+        ((1, 3),           0),
+        ((3, 1),           1),
+        ((3, 1),          -1),
+        ((1, 1, 3),        None),
+        ((1,),             0),
+    ]
+
+    for shape, axis in configs:
+        size = dr.prod(shape)
+        v_dr = t(dr.arange(dr.array_t(t), size), shape)
+        v_np = np.arange(size).reshape(shape)
+
+        out_dr = dr.squeeze(v_dr) if axis is None else dr.squeeze(v_dr, axis=axis)
+        out_np = np.squeeze(v_np) if axis is None else np.squeeze(v_np, axis=axis)
+
+        assert out_dr.shape == out_np.shape, \
+            f"shape mismatch for input {shape}, axis={axis}"
+        assert np.allclose(out_np, out_dr.numpy())
+
+    # squeeze to 0-d
+    assert dr.squeeze(t(dr.array_t(t)(42), (1, 1, 1))).shape == ()
+
+    # error cases
+    v = t(dr.arange(dr.array_t(t), 6), (2, 3))
+    with pytest.raises(RuntimeError, match="not 1"):
+        dr.squeeze(v, axis=0)
+    with pytest.raises(RuntimeError, match="out of bounds"):
+        dr.squeeze(v, axis=3)
+    with pytest.raises(TypeError, match="expected a tensor"):
+        dr.squeeze(dr.array_t(t)(1, 2, 3), axis=0)
+
+
+@pytest.test_arrays('is_tensor, jit, uint32')
+def test35_transpose(t):
+    np = pytest.importorskip("numpy")
+
+    configs = [
+        ((3, 4),          None),
+        ((3, 4),          (1, 0)),
+        ((2, 3, 4),       None),
+        ((2, 3, 4),       (2, 0, 1)),
+        ((2, 3, 4),       (1, 0, 2)),
+        ((2, 3, 4),       (0, 2, 1)),
+        ((2, 3, 4),       (-1, -2, -3)),
+        ((2, 3, 4, 5),    None),
+        ((2, 3, 4, 5),    (3, 1, 0, 2)),
+    ]
+
+    for shape, axes in configs:
+        size = dr.prod(shape)
+        v_dr = t(dr.arange(dr.array_t(t), size), shape)
+        v_np = np.arange(size).reshape(shape)
+
+        out_dr = dr.transpose(v_dr) if axes is None else dr.transpose(v_dr, axes)
+        out_np = np.transpose(v_np) if axes is None else np.transpose(v_np, axes)
+
+        assert out_dr.shape == out_np.shape, \
+            f"shape mismatch for input {shape}, axes={axes}"
+        assert np.allclose(out_np, out_dr.numpy())
+
+    # error cases
+    v = t(dr.arange(dr.array_t(t), 6), (2, 3))
+    with pytest.raises(TypeError, match="expected a tensor"):
+        dr.transpose(dr.array_t(t)(1, 2, 3))
+    with pytest.raises(RuntimeError, match="must have length 2"):
+        dr.transpose(v, (0,))
+    with pytest.raises(RuntimeError, match="out of bounds"):
+        dr.transpose(v, (0, 5))
+    with pytest.raises(RuntimeError, match="must be a permutation"):
+        dr.transpose(v, (0, 0))
+
+
+@pytest.test_arrays('is_tensor, jit, uint32')
+def test36_swapaxes(t):
+    np = pytest.importorskip("numpy")
+
+    configs = [
+        ((3, 4),       0,  1),
+        ((2, 3, 4),    0,  1),
+        ((2, 3, 4),    0,  2),
+        ((2, 3, 4),    1,  2),
+        ((2, 3, 4),    0, -1),
+        ((2, 3, 4),   -1, -2),
+        ((2, 3, 4, 5), 1,  3),
+    ]
+
+    for shape, ax1, ax2 in configs:
+        size = dr.prod(shape)
+        v_dr = t(dr.arange(dr.array_t(t), size), shape)
+        v_np = np.arange(size).reshape(shape)
+
+        out_dr = dr.swapaxes(v_dr, ax1, ax2)
+        out_np = np.swapaxes(v_np, ax1, ax2)
+
+        assert out_dr.shape == out_np.shape, \
+            f"shape mismatch for input {shape}, axes=({ax1},{ax2})"
+        assert np.allclose(out_np, out_dr.numpy())
+
+    with pytest.raises(TypeError, match="expected a tensor"):
+        dr.swapaxes(dr.array_t(t)(1, 2, 3), 0, 1)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -83,6 +83,37 @@ def test01_slice_index(t):
     check(shape=(3, 7), indices=(None, ..., None, 1, None),
           shape_out=(1, 3, 1, 1), index_out=t(1, 8, 15))
 
+    # Higher-dim cases that exercise the generalized passthrough-run
+    # coalesce, multi-run patterns, and the length-1 fancy-gather guard.
+
+    # 3D: trailing 2-passthrough collapse
+    check(shape=(3, 4, 5), indices=(2, slice(None), slice(None)),
+          shape_out=(4, 5), index_out=dr.arange(t, 20) + 40)
+    # 3D: leading 2-passthrough collapse (only reachable via the
+    # generalized coalesce -- a trailing-only collapse would miss it)
+    check(shape=(3, 4, 5), indices=(slice(None), slice(None), 2),
+          shape_out=(3, 4), index_out=dr.arange(t, 12) * 5 + 2)
+    # 3D: passthrough between two integer indices (middle live axis)
+    check(shape=(3, 4, 5), indices=(1, slice(None), 2),
+          shape_out=(4,), index_out=dr.arange(t, 4) * 5 + 22)
+    # 3D: length-1 fancy gather between passthroughs (regression for
+    # the coalesce self-move guard, which would otherwise null the
+    # gather array's nb::object on the first iteration)
+    check(shape=(3, 4, 5), indices=(slice(None), t(0), slice(None)),
+          shape_out=(3, 1, 5),
+          index_out=t(0, 1, 2, 3, 4, 20, 21, 22, 23, 24,
+                      40, 41, 42, 43, 44))
+    # 3D: size-1 input dim collapses to a slice_size==1 synthetic axis
+    # that the main loop must skip (is_skippable)
+    check(shape=(3, 1, 5), indices=(1, slice(None), 2),
+          shape_out=(1,), index_out=t(7))
+    # 4D: two separate passthrough runs split by integer indices
+    check(shape=(2, 3, 4, 5), indices=(1, slice(None), 2, slice(None)),
+          shape_out=(3, 5),
+          index_out=t(70, 71, 72, 73, 74,
+                      90, 91, 92, 93, 94,
+                      110, 111, 112, 113, 114))
+
 
 @pytest.test_arrays('is_tensor, -bool')
 def test02_construct(t):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -819,3 +819,139 @@ def test30_transpose_matrix(t):
     m_T = t(*vals_T)
     assert dr.all(m.T == m_T, axis=None)
     assert dr.all(m.mT == m_T, axis=None)
+
+
+@pytest.test_arrays('is_tensor, jit, uint32')
+def test31_expand_dims(t):
+    np = pytest.importorskip("numpy")
+
+    configs = [
+        ((5,),      0),
+        ((5,),      1),
+        ((5,),     -1),
+        ((5,),     -2),
+        ((3, 4),    0),
+        ((3, 4),    1),
+        ((3, 4),    2),
+        ((3, 4),   -1),
+        ((2, 3, 4), 0),
+        ((2, 3, 4), 2),
+        ((2, 3, 4), 3),
+        ((2, 3, 4), -1),
+        # tuple axis
+        ((3, 4),  (0, 2)),
+        ((3, 4),  (0, -1)),
+        ((3, 4),  (0, 1)),
+        ((5,),    (0, 2)),
+        ((2, 3),  (0, 1, 4)),
+    ]
+
+    for shape, axis in configs:
+        size = dr.prod(shape)
+        v_dr = t(dr.arange(dr.array_t(t), size), shape)
+        v_np = np.arange(size).reshape(shape)
+
+        out_dr = dr.expand_dims(v_dr, axis=axis)
+        out_np = np.expand_dims(v_np, axis=axis)
+
+        assert out_dr.shape == out_np.shape, \
+            f"shape mismatch for input {shape}, axis={axis}"
+        assert np.allclose(out_np, out_dr.numpy())
+
+    v = t(dr.arange(dr.array_t(t), 6), (2, 3))
+    with pytest.raises(RuntimeError, match="out of bounds"):
+        dr.expand_dims(v, axis=4)
+    with pytest.raises(RuntimeError, match="duplicate"):
+        dr.expand_dims(v, axis=(0, 0))
+    with pytest.raises(TypeError, match="expected a tensor"):
+        dr.expand_dims(dr.array_t(t)(1, 2, 3), axis=0)
+
+
+@pytest.test_arrays('is_tensor, jit, uint32')
+def test32_stack(t):
+    np = pytest.importorskip("numpy")
+
+    configs = [
+        (0,  (3,),       (3,)),
+        (1,  (3,),       (3,)),
+        (-1, (3,),       (3,)),
+        (0,  (2, 3),     (2, 3)),
+        (1,  (2, 3),     (2, 3)),
+        (2,  (2, 3),     (2, 3)),
+        (-1, (2, 3),     (2, 3)),
+        (0,  (2, 3),     (2, 3), (2, 3)),
+        (0,  (2, 3, 4),  (2, 3, 4)),
+        (2,  (2, 3, 4),  (2, 3, 4)),
+        (-1, (2, 3, 4),  (2, 3, 4)),
+    ]
+
+    for axis, *shapes in configs:
+        in_drjit = []
+        in_numpy = []
+        for i, shape in enumerate(shapes):
+            size = dr.prod(shape)
+            in_drjit.append(t(dr.arange(dr.array_t(t), size) + i * 100, shape))
+            in_numpy.append(np.arange(size).reshape(shape) + i * 100)
+
+        out_np = np.stack(in_numpy, axis=axis)
+        out_dr = dr.stack(in_drjit, axis=axis)
+
+        assert out_dr.shape == out_np.shape, \
+            f"shape mismatch for axis={axis}, shapes={shapes}"
+        assert np.allclose(out_np, out_dr.numpy())
+
+    # single-element input
+    v_dr = t(dr.arange(dr.array_t(t), 6), (2, 3))
+    v_np = np.arange(6).reshape(2, 3)
+    assert dr.stack([v_dr]).shape == np.stack([v_np]).shape
+
+    # error cases
+    a = t(dr.arange(dr.array_t(t), 6), (2, 3))
+    b = t(dr.arange(dr.array_t(t), 12), (3, 4))
+    with pytest.raises(TypeError, match="same shape"):
+        dr.stack([a, b])
+    with pytest.raises(RuntimeError, match="out of bounds"):
+        dr.stack([a, a], axis=3)
+    with pytest.raises(TypeError, match="expected tensor"):
+        dr.stack([dr.array_t(t)(1, 2)])
+    with pytest.raises(RuntimeError, match="at least one"):
+        dr.stack([])
+
+
+@pytest.test_arrays('is_tensor, jit, uint32')
+def test33_vstack_hstack_column_stack_dstack(t):
+    np = pytest.importorskip("numpy")
+
+    def check(dr_fn, np_fn, shapes):
+        in_drjit, in_numpy = [], []
+        for i, shape in enumerate(shapes):
+            size = dr.prod(shape)
+            in_drjit.append(t(dr.arange(dr.array_t(t), size) + i * 100, shape))
+            in_numpy.append(np.arange(size).reshape(shape) + i * 100)
+        out_dr = dr_fn(in_drjit)
+        out_np = np_fn(in_numpy)
+        assert out_dr.shape == out_np.shape, \
+            f"shape mismatch for {dr_fn.__name__}, shapes={shapes}"
+        assert np.allclose(out_np, out_dr.numpy())
+
+    for shapes in [((3,), (3,)), ((3,), (3,), (3,)), ((2,3), (2,3)),
+                   ((2,3), (1,3)), ((2,3,4), (3,3,4))]:
+        check(dr.vstack, np.vstack, shapes)
+
+    for shapes in [((3,), (4,)), ((3,), (4,), (2,)), ((2,3), (2,4)),
+                   ((2,3), (2,4), (2,1)), ((2,3,4), (2,5,4))]:
+        check(dr.hstack, np.hstack, shapes)
+
+    for shapes in [((3,), (3,)), ((3,), (3,), (3,)),
+                   ((2,3), (2,4)), ((2,1), (2,3))]:
+        check(dr.column_stack, np.column_stack, shapes)
+
+    for shapes in [((3,), (3,)), ((2,3), (2,3)), ((2,3,4), (2,3,5))]:
+        check(dr.dstack, np.dstack, shapes)
+
+    # non-tensor rejection
+    a = dr.array_t(t)(1, 2, 3)
+    for fn in [dr.vstack, dr.hstack, dr.column_stack, dr.dstack]:
+        with pytest.raises(TypeError, match="expected tensor"):
+            fn([a, a])
+


### PR DESCRIPTION
This PR adds a large set of NumPy-compatible array and tensor manipulation functions.

### Sorting

- **`dr.sort(value, axis, descending)`** — stable sort of arrays and tensors. Uses a multi-bit radix sort that runs efficiently on the CUDA/LLVM backends.

- **`dr.argsort(value, axis, descending)`** — same as `sort()` but returns the permutation index array rather than the sorted values.

### Reductions with axis support

- **`dr.argmin(value, axis, keepdims)`** and **`dr.argmax(value, axis, keepdims)`** — return the flat or per-axis index of the minimum/maximum element.

### Shape manipulation

- **`dr.expand_dims(a, axis)`** — insert a length-1 axis.
- **`dr.squeeze(a, axis)`** — remove length-1 axes (inverse of `expand_dims`).
- **`dr.transpose(a, axes)`** — permute axes arbitrarily; defaults to full reversal.
- **`dr.swapaxes(a, axis1, axis2)`** — exchange two axes.

### Joining and splitting

- **`dr.stack(arrays, axis)`**, **`dr.vstack()`**, **`dr.hstack()`**, **`dr.column_stack()`**, **`dr.dstack()`** — NumPy-compatible stacking functions, all implemented as thin wrappers around `dr.reshape()` and `dr.concat()`. `dr.row_stack()` is provided as an alias for `dr.vstack()`.
- **`dr.split(a, indices_or_sections, axis)`** — split a tensor into equal parts or at given indices.
- **`dr.array_split(a, indices_or_sections, axis)`** — split with unequal sections allowed.

These functions reject non-tensor inputs with an error message.

## Index-computation simplifications

Three existing primitives received closed-form index rewrites that reduce the number of JIT-compiled arithmetic operations:

- **`concat()`** — replaced an O(axis) per-dimension div/mod/mul loop with a formula requiring at most one div + one mod regardless of tensor rank. For the common `axis=0` case this further reduces to a single addition.

- **`slice_index()`** — contiguous runs of passthrough (`:`) axes are collapsed into a single synthetic axis, cutting the number of additions and multiplies emitted by the JIT.

- **`moveaxis()`** — the leading prefix of axes that don't change position is now skipped in one step (one mod + one subtract) instead of iterating through each prefix axis. For `swapaxes(t, k, k+1)` on an *n*-dim tensor this drops the loop from `k+2` iterations to 2.
