### PR TITLE
Extend dr.convolve kernel and boundary handling

### DIFF
--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -2764,18 +2764,137 @@ def resample(
     else:
         return value
 
+def _convolve_discrete(source: ArrayT, kernel: ArrayBase,
+                       axis: Union[int, Tuple[int, ...], None],
+                       boundary: Literal["normalize", "zero"]) -> ArrayT:
+    """Implementation detail of drjit.convolve() for discrete 1D kernels."""
+
+    shape = source.shape
+    strides = _compute_strides(shape)
+    ndim = len(shape)
+    source_tp = type(source)
+    value = source.array
+
+    if is_tensor_v(kernel) or not is_array_v(kernel) or depth_v(type(kernel)) != 1:
+        raise TypeError(
+            "drjit.convolve(): a discrete 'filter' must be a 1D Dr.Jit "
+            "array.")
+
+    kernel_shape = kernel.shape
+    if len(kernel_shape) != 1:
+        raise RuntimeError(
+            "drjit.convolve(): a discrete 'filter' must be one-dimensional.")
+
+    kernel_size = kernel_shape[0]
+    if kernel_size == 0:
+        raise RuntimeError(
+            "drjit.convolve(): a discrete 'filter' cannot be empty.")
+
+    if axis is None:
+        axis = tuple(range(ndim))
+    else:
+        axis = _normalize_axis_tuple(axis, ndim, 'axis')
+
+    total = prod(shape)
+    center = kernel_size // 2
+
+    for i in axis:
+        res = shape[i]
+        if res == 0:
+            raise RuntimeError(
+                "drjit.convolve(): source resolution cannot be zero.")
+
+        stride = strides[i]
+        Array = type(value)
+        Accum = float32_array_t(Array) if itemsize_v(Array) <= 4 else Array
+        Index = uint32_array_t(Array)
+        KernelArray = type(kernel)
+        KernelIndex = uint32_array_t(KernelArray)
+        kernel_dynamic = is_dynamic_v(KernelArray)
+
+        index_out = arange(Index, total)
+        axis_index = (index_out // stride) % res
+        target = zeros(Accum, total)
+        kernel_sum = zeros(Accum, total)
+        valid_sum = zeros(Accum, total)
+        right_radius = kernel_size - center - 1
+
+        renormalize = None
+        if center > 0:
+            renormalize = axis_index < center
+        if right_radius > 0:
+            right_boundary = axis_index + right_radius >= res
+            renormalize = (
+                right_boundary if renormalize is None
+                else renormalize | right_boundary
+            )
+
+        for k in range(kernel_size):
+            if kernel_dynamic:
+                weight = Accum(gather(
+                    KernelArray,
+                    kernel,
+                    full(KernelIndex, k, total)
+                ))
+            else:
+                weight = Accum(kernel[k])
+            offset = k - center
+
+            if offset < 0:
+                active = axis_index >= -offset
+                source_index = index_out - (-offset) * stride
+                source_index = select(active, source_index, Index(0))
+            elif offset > 0:
+                active = axis_index + offset < res
+                source_index = index_out + offset * stride
+                source_index = select(active, source_index, Index(0))
+            else:
+                active = None
+                source_index = index_out
+
+            active_weight = (
+                weight != Accum(0) if active is None
+                else active & (weight != Accum(0))
+            )
+            sample = gather(Array, value, source_index, active_weight)
+            target = fma(weight, Accum(sample), target)
+            kernel_sum += weight
+            valid_sum += (
+                weight if active is None
+                else select(active, weight, Accum(0))
+            )
+
+        if boundary == "normalize" and renormalize is not None:
+            valid = renormalize & (valid_sum != Accum(0))
+            scale = select(
+                valid,
+                kernel_sum / select(valid, valid_sum, Accum(1)),
+                Accum(1)
+            )
+            target *= scale
+
+        value = Array(target)
+
+    if is_tensor_v(source_tp):
+        return source_tp(value, shape)
+    else:
+        return value
+
+
 def convolve(
     source: ArrayT,
-    filter: Union[Literal["box", "linear", "hamming", "cubic", "lanczos", "gaussian"], Callable[[float], float]],
-    filter_radius: float,
-    axis: Union[int, Tuple[int, ...], None] = None
+    filter: Union[Literal["box", "linear", "hamming", "cubic", "lanczos", "gaussian"], Callable[[float], float], ArrayBase],
+    filter_radius: Optional[float] = None,
+    axis: Union[int, Tuple[int, ...], None] = None,
+    boundary: Literal["normalize", "zero"] = "normalize"
 ) -> ArrayT:
     """
     Convolve one or more axes of an input array/tensor with a 1D filter
 
     This function filters one or more axes of a Dr.Jit array or tensor, for
     example to convolve an image with a 2D Gaussian filter to blur spatial
-    detail.
+    detail. The filter can be either a continuous kernel specified by name or
+    callable, or a discrete 1D Dr.Jit array kernel.
 
     .. code-block:: python
 
@@ -2787,8 +2906,10 @@ def convolve(
            filter_radius=10
        )
 
-    The filter weights are renormalized to reduce edge effects near the
-    boundary of the array.
+    Near the boundary of the array, the ``boundary`` parameter controls whether
+    out-of-bounds samples are treated as zero or the remaining in-bounds weights
+    are rescaled to preserve the full filter footprint's weight sum. Away from
+    boundaries, filter weights are used as provided/sampled.
 
     The function supports a set of provided filters, and custom filters
     can also be specified. This works analogously to the :py:func:`resample`
@@ -2797,21 +2918,50 @@ def convolve(
     Args:
         source (dr.ArrayBase): The Dr.Jit tensor or 1D array to be resampled.
 
-        filter (str | Callable[[float], float])
+        filter (str | Callable[[float], float] | dr.ArrayBase)
           The desired reconstruction filter, see the above text for an overview.
-          Alternatively, a custom reconstruction filter function can also be
-          specified.
+          Alternatively, a custom reconstruction filter function or a discrete
+          1D Dr.Jit array kernel can also be specified.
 
-        filter_radius (float)
-          The radius of the continous function to be used in the convolution.
+        filter_radius (float | None)
+          The radius of the continuous function to be used in the convolution.
+          This must be specified for continuous filters and must not be
+          specified for discrete kernels.
 
         axis (int | tuple[int, ...] | ... | None): The axis or set of axes
           along which to convolve. The default argument ``axis=None`` causes all
           axes to be convolved. Negative values count from the last dimension.
 
+        boundary ("normalize" | "zero"): Boundary handling mode. The default
+          ``"normalize"`` rescales clipped kernel weights near boundaries so
+          that their sum matches the full kernel sum. ``"zero"`` uses zero
+          padding and does not rescale clipped kernel weights. If a
+          unit-normalized discrete kernel is desired, normalize the kernel
+          before passing it to ``dr.convolve()``.
+
     Returns:
         drjit.ArrayBase: The resampled output array. Its type matches ``source``.
     """
+
+    if boundary not in ("normalize", "zero"):
+        raise ValueError(
+            "drjit.convolve(): 'boundary' must be 'normalize' or 'zero'.")
+
+    if is_array_v(filter) and not is_tensor_v(filter):
+        if filter_radius is not None:
+            raise TypeError(
+                "drjit.convolve(): 'filter_radius' cannot be specified when "
+                "using a discrete filter.")
+        return _convolve_discrete(source, filter, axis, boundary)
+
+    if is_tensor_v(filter) or not (isinstance(filter, str) or callable(filter)):
+        raise TypeError(
+            "drjit.convolve(): a discrete 'filter' must be a 1D Dr.Jit array.")
+
+    if filter_radius is None:
+        raise TypeError(
+            "drjit.convolve(): 'filter_radius' must be specified when using "
+            "a continuous filter.")
 
     shape = source.shape
     strides = _compute_strides(shape)
@@ -2830,7 +2980,7 @@ def convolve(
         res = shape[i]
 
         # Cache resampler in case it can be reused
-        key = (res, res, filter, filter_radius)
+        key = (res, res, filter, filter_radius, boundary)
 
         resampler = _resample_cache.get(key, None)
         if resampler is None:
@@ -2839,7 +2989,8 @@ def convolve(
                 target_res=res,
                 filter=filter,
                 filter_radius=filter_radius,
-                convolve=True
+                convolve=True,
+                boundary=boundary
             )
             _resample_cache[key] = resampler
 

--- a/drjit/__init__.py
+++ b/drjit/__init__.py
@@ -2817,11 +2817,12 @@ def _convolve_discrete(source: ArrayT, kernel: ArrayBase,
         target = zeros(Accum, total)
         kernel_sum = zeros(Accum, total)
         valid_sum = zeros(Accum, total)
-        right_radius = kernel_size - center - 1
+        left_radius = kernel_size - center - 1
+        right_radius = center
 
         renormalize = None
-        if center > 0:
-            renormalize = axis_index < center
+        if left_radius > 0:
+            renormalize = axis_index < left_radius
         if right_radius > 0:
             right_boundary = axis_index + right_radius >= res
             renormalize = (
@@ -2838,7 +2839,7 @@ def _convolve_discrete(source: ArrayT, kernel: ArrayBase,
                 ))
             else:
                 weight = Accum(kernel[k])
-            offset = k - center
+            offset = center - k
 
             if offset < 0:
                 active = axis_index >= -offset
@@ -2881,9 +2882,37 @@ def _convolve_discrete(source: ArrayT, kernel: ArrayBase,
         return value
 
 
+_ConvolveContinuousFilter = Union[
+    Literal["box", "linear", "hamming", "cubic", "lanczos", "gaussian"],
+    Callable[[float], float]
+]
+
+
+@overload
 def convolve(
     source: ArrayT,
-    filter: Union[Literal["box", "linear", "hamming", "cubic", "lanczos", "gaussian"], Callable[[float], float], ArrayBase],
+    filter: _ConvolveContinuousFilter,
+    filter_radius: float,
+    axis: Union[int, Tuple[int, ...], None] = None,
+    boundary: Literal["normalize", "zero"] = "normalize"
+) -> ArrayT:
+    ...
+
+
+@overload
+def convolve(
+    source: ArrayT,
+    filter: ArrayBase,
+    *,
+    axis: Union[int, Tuple[int, ...], None] = None,
+    boundary: Literal["normalize", "zero"] = "normalize"
+) -> ArrayT:
+    ...
+
+
+def convolve(
+    source: ArrayT,
+    filter: Union[_ConvolveContinuousFilter, ArrayBase],
     filter_radius: Optional[float] = None,
     axis: Union[int, Tuple[int, ...], None] = None,
     boundary: Literal["normalize", "zero"] = "normalize"

--- a/include/drjit/resample.h
+++ b/include/drjit/resample.h
@@ -29,6 +29,11 @@ NAMESPACE_BEGIN(drjit)
 class DRJIT_EXTRA_EXPORT Resampler {
 public:
     using Filter = double (*)(double x, const void *payload);
+    enum class FilterNormalization {
+        Unit,
+        Boundary,
+        None
+    };
 
     /**
      * Create a Resampler that uses a predefined reconstruction filter to
@@ -66,7 +71,8 @@ public:
      * filter kernel radius.
      */
     Resampler(uint32_t source_res, uint32_t target_res, const char *filter,
-              double radius_scale = 1.0);
+              double radius_scale = 1.0,
+              FilterNormalization normalization = FilterNormalization::Unit);
 
     /**
      * \brief Construct a Resampler using a custom filter kernel.
@@ -80,7 +86,8 @@ public:
      * zero for positions ``x`` outside of the interval ``[-radius, radius]``.
      */
     Resampler(uint32_t source_res, uint32_t target_res, Filter filter,
-              const void *payload, double radius);
+              const void *payload, double radius,
+              FilterNormalization normalization = FilterNormalization::Unit);
 
     /// Free the resampler object
     ~Resampler();

--- a/src/extra/resample.cpp
+++ b/src/extra/resample.cpp
@@ -29,7 +29,8 @@ struct Resampler::Impl {
     mutable std::any weights_cache;
 
     Impl(uint32_t source_res, uint32_t target_res, Resampler::Filter filter,
-         const void *payload, double radius, double radius_scale)
+         const void *payload, double radius, double radius_scale,
+         Resampler::FilterNormalization normalization)
         : source_res(source_res), target_res(target_res) {
         if (source_res == 0 || target_res == 0)
             drjit_raise("drjit.Resampler(): source/target resolution cannot be zero!");
@@ -58,11 +59,12 @@ struct Resampler::Impl {
             double center = (i + 0.5) * scale;
 
             // Index of the first original sample that might contribute
-            uint32_t offset_i =
-                (uint32_t) std::max(0, (int) (center - radius + .5));
+            int offset_unclamped = (int) (center - radius + .5);
+            uint32_t offset_i = (uint32_t) std::max(0, offset_unclamped);
             offset[i] = offset_i;
 
-            double sum = 0.0;
+            double sum = 0.0,
+                   sum_full = 0.0;
             for (uint32_t l = 0; l < taps; l++) {
                 // Relative position of sample in the filter frame
                 double rel = (offset_i - center + l + .5) * filter_scale;
@@ -72,18 +74,28 @@ struct Resampler::Impl {
                     weight = filter(rel, payload);
                 weights[i * taps + l] = weight;
                 sum += weight;
+
+                if (normalization == Resampler::FilterNormalization::Boundary) {
+                    double rel_full =
+                        (offset_unclamped - center + l + .5) * filter_scale;
+                    sum_full += filter(rel_full, payload);
+                }
             }
 
-            if (sum == 0)
+            if (sum == 0 && normalization != Resampler::FilterNormalization::None)
                 drjit_raise(
                     "drjit.Resampler(): the filter footprint is too small; the "
                     "support of some output samples does not contain any input "
                     "samples!");
 
-            // Normalize the weights for each output sample
-            double normalization = 1.0 / sum;
+            double normalization_value = 1.0;
+            if (normalization == Resampler::FilterNormalization::Unit)
+                normalization_value = 1.0 / sum;
+            else if (normalization == Resampler::FilterNormalization::Boundary)
+                normalization_value = sum_full / sum;
+
             for (uint32_t l = 0; l < taps; l++)
-                weights[i * taps + l] *= normalization;
+                weights[i * taps + l] *= normalization_value;
         }
     }
 
@@ -129,7 +141,9 @@ static inline double sinc(double x) {
     return std::sin(x) / x;
 }
 
-Resampler::Resampler(uint32_t source_res, uint32_t target_res, const char *filter, double radius_scale) {
+Resampler::Resampler(uint32_t source_res, uint32_t target_res,
+                     const char *filter, double radius_scale,
+                     Resampler::FilterNormalization normalization) {
     Resampler::Filter filter_cb = nullptr;
     double radius = 0.0;
 
@@ -191,13 +205,16 @@ Resampler::Resampler(uint32_t source_res, uint32_t target_res, const char *filte
                     "'hamming', 'cubic', and 'lanczos' are supported).");
     }
 
-    d = new Impl(source_res, target_res, filter_cb, nullptr, radius, radius_scale);
+    d = new Impl(source_res, target_res, filter_cb, nullptr, radius,
+                 radius_scale, normalization);
 }
 
 Resampler::Resampler(uint32_t source_res, uint32_t target_res,
                      Resampler::Filter filter, const void *payload,
-                     double radius)
-    : d(new Impl(source_res, target_res, filter, payload, radius, 1.0)) {
+                     double radius,
+                     Resampler::FilterNormalization normalization)
+    : d(new Impl(source_res, target_res, filter, payload, radius, 1.0,
+                 normalization)) {
 }
 
 Resampler::~Resampler() { }

--- a/src/python/resample.cpp
+++ b/src/python/resample.cpp
@@ -11,27 +11,50 @@
 #include <drjit/resample.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/optional.h>
+#include <cstring>
 #include "common.h"
 
 void export_resample(nb::module_ &) {
     nb::object detail = nb::module_::import_("drjit").attr("detail");
     using dr::Resampler;
 
+    auto parse_normalization = [](bool convolve, const char *boundary) -> Resampler::FilterNormalization {
+        if (!convolve)
+            return Resampler::FilterNormalization::Unit;
+
+        if (std::strcmp(boundary, "normalize") == 0)
+            return Resampler::FilterNormalization::Boundary;
+        else if (std::strcmp(boundary, "zero") == 0)
+            return Resampler::FilterNormalization::None;
+        else
+            nb::raise("drjit.Resampler(): 'boundary' must be 'normalize' or 'zero'.");
+        return Resampler::FilterNormalization::Unit;
+    };
+
     auto resampler = nb::class_<Resampler>(detail, "Resampler")
-        .def("__init__", [](Resampler *self, uint32_t source_res, uint32_t target_res,
-                            const char *filter, std::optional<double> filter_radius, bool convolve) {
+        .def("__init__", [parse_normalization](Resampler *self, uint32_t source_res, uint32_t target_res,
+                                                const char *filter, std::optional<double> filter_radius,
+                                                bool convolve, const char *boundary) {
                  if (filter_radius.has_value() && !convolve)
                      nb::raise("drjit.Resampler(): 'filter_radius' must be None when using a filter preset.");
-                 new (self) Resampler(source_res, target_res, filter, filter_radius.has_value() ? filter_radius.value() : 1.0);
-             }, "source_res"_a, "target_res"_a, "filter"_a, "filter_radius"_a = nb::none(), "convolve"_a = false)
-        .def("__init__", [](Resampler *self, uint32_t source_res, uint32_t target_res,
-                            nb::typed<nb::callable, float, float> filter, double filter_radius, bool) {
+                 new (self) Resampler(
+                     source_res, target_res, filter,
+                     filter_radius.has_value() ? filter_radius.value() : 1.0,
+                     parse_normalization(convolve, boundary)
+                 );
+             }, "source_res"_a, "target_res"_a, "filter"_a, "filter_radius"_a = nb::none(), "convolve"_a = false,
+                "boundary"_a = "normalize")
+        .def("__init__", [parse_normalization](Resampler *self, uint32_t source_res, uint32_t target_res,
+                                                nb::typed<nb::callable, float, float> filter, double filter_radius,
+                                                bool convolve, const char *boundary) {
                  Resampler::Filter filter_cb = [](double v, const void *ptr) -> double {
                      return nb::cast<double>(nb::handle((PyObject *) ptr)(v));
                  };
                  new (self) Resampler(source_res, target_res, filter_cb,
-                                      filter.ptr(), filter_radius);
-             }, "source_res"_a, "target_res"_a, "filter"_a, "filter_radius"_a, "convolve"_a = false)
+                                      filter.ptr(), filter_radius,
+                                      parse_normalization(convolve, boundary));
+             }, "source_res"_a, "target_res"_a, "filter"_a, "filter_radius"_a, "convolve"_a = false,
+                "boundary"_a = "normalize")
 #if defined(DRJIT_ENABLE_CUDA)
          .def("resample_fwd",
               (dr::CUDAArray<dr::half>(Resampler::*)(const dr::CUDAArray<dr::half> &, uint32_t) const) &Resampler::resample_fwd,
@@ -92,4 +115,3 @@ void export_resample(nb::module_ &) {
                     + "]";
               });
 }
-

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -111,5 +111,44 @@ def test07_convolve(t):
     assert dr.allclose(x, y)
 
     y = dr.convolve(x, 'linear', 2)
-    z = t((1+2*.5)/1.5, (1*.5+2+10*.5)/2, (2*.5+10+100*.5)/2, (100+10*.5)/1.5)
+    z = t((1+2*.5)*2/1.5, 1*.5+2+10*.5, 2*.5+10+100*.5, (100+10*.5)*2/1.5)
     assert dr.allclose(y, z)
+
+    y = dr.convolve(x, 'linear', 2, boundary='zero')
+    z = t(1+2*.5, 1*.5+2+10*.5, 2*.5+10+100*.5, 100+10*.5)
+    assert dr.allclose(y, z)
+
+
+# Test convolution with a discrete 1D kernel
+@pytest.test_arrays('float, -jit, shape=(*)')
+def test08_convolve_discrete_1d(t):
+    x = t(1, 2, 10, 100)
+    kernel = t(1, 2, 1)
+
+    y = dr.convolve(x, kernel, boundary='zero')
+    assert dr.allclose(y, t(4, 15, 122, 210))
+
+    y = dr.convolve(x, kernel)
+    assert dr.allclose(y, t(16/3, 15, 122, 280))
+
+    kernel_t = dr.tensor_t(t)([1, 2, 1])
+    with pytest.raises(TypeError, match="must be a 1D Dr.Jit array"):
+        dr.convolve(x, kernel_t)
+
+    with pytest.raises(TypeError, match="must be a 1D Dr.Jit array"):
+        dr.convolve(x, [1, 2, 1])
+
+
+# Test discrete convolution over selected tensor axes
+@pytest.test_arrays('float, -jit, tensor')
+def test09_convolve_discrete_tensor_axis(t):
+    x = t([[1, 2, 3], [4, 5, 6]])
+    kernel = dr.array_t(t)(1, 2, 1)
+
+    y = dr.convolve(x, kernel, axis=1)
+    z = t([[16/3, 8, 32/3], [52/3, 20, 68/3]])
+    assert dr.all(dr.allclose(y, z), axis=None)
+
+    y = dr.convolve(x, kernel, axis=0, boundary='zero')
+    z = t([[6, 9, 12], [9, 12, 15]])
+    assert dr.all(dr.allclose(y, z), axis=None)

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -131,6 +131,14 @@ def test08_convolve_discrete_1d(t):
     y = dr.convolve(x, kernel)
     assert dr.allclose(y, t(16/3, 15, 122, 280))
 
+    kernel = t(1, 2, 3)
+
+    y = dr.convolve(t(1, 2, 3, 4), kernel, boundary='zero')
+    assert dr.allclose(y, t(4, 10, 16, 17))
+
+    y = dr.convolve(t(1, 2, 3, 4), kernel)
+    assert dr.allclose(y, t(8, 10, 16, 102/5))
+
     kernel_t = dr.tensor_t(t)([1, 2, 1])
     with pytest.raises(TypeError, match="must be a 1D Dr.Jit array"):
         dr.convolve(x, kernel_t)
@@ -152,3 +160,16 @@ def test09_convolve_discrete_tensor_axis(t):
     y = dr.convolve(x, kernel, axis=0, boundary='zero')
     z = t([[6, 9, 12], [9, 12, 15]])
     assert dr.all(dr.allclose(y, z), axis=None)
+
+
+# Test discrete convolution on JIT backends
+@pytest.test_arrays('float32, jit, shape=(*)')
+def test10_convolve_discrete_1d_jit(t):
+    x = t(1, 2, 3, 4)
+    kernel = t(1, 2, 3)
+
+    y = dr.convolve(x, kernel, boundary='zero')
+    assert dr.allclose(y, t(4, 10, 16, 17))
+
+    y = dr.convolve(x, kernel)
+    assert dr.allclose(y, t(8, 10, 16, 102/5))


### PR DESCRIPTION
## Summary

This PR extends `dr.convolve()` in two ways: it adds support for discrete 1D Dr.Jit array kernels, and it makes boundary handling explicit through a new `boundary` parameter.

The existing continuous-filter interface remains available for preset filter names and callable filters. Discrete kernels are selected automatically when the `filter` argument is a 1D Dr.Jit array.

### Discrete Kernel Support

`dr.convolve()` can now take a 1D Dr.Jit array as its filter argument:

```python
kernel = dr.scalar.ArrayXf(1, 2, 1)
y = dr.convolve(x, kernel)
```

The existing `axis` behavior is preserved:

- `axis=None` applies separable convolution along all axes.
- `axis=int` or `axis=tuple[int, ...]` restricts convolution to the selected axes.

The output shape is unchanged and matches the input shape. 

Discrete kernels use the standard convolution orientation, so non-symmetric
kernels are applied in the convolution direction rather than as correlation
kernels.

### Boundary Parameter

This PR adds:

```python
boundary="normalize"
boundary="zero"
```

`boundary="normalize"` is the default. When a kernel is truncated at the boundary, the remaining kernel weights are rescaled so that their sum matches the full kernel sum. In the interior, no normalization is applied: discrete kernel weights are used as provided, and continuous kernel weights are used as sampled. If a unit-normalized kernel is desired, users should normalize the kernel before passing it to `dr.convolve()`.

`boundary="zero"` uses zero padding and does not rescale the truncated kernel weights. In the interior, `boundary="zero"` produces the same result as `boundary="normalize"`. The two modes only differ near boundaries. 

This updated normalization behavior applies to `dr.convolve()`. `dr.resample()` keeps its previous behavior.

### Implementation Details

- Added `boundary: Literal["normalize", "zero"] = "normalize"` to `dr.convolve`.
- Added `@typing.overload` interfaces for the continuous-filter and discrete-kernel forms of `dr.convolve`.
- Added runtime dispatch: preset filter names and callables use the continuous path, while 1D Dr.Jit arrays use the discrete-kernel path.
- Added an internal `Resampler::FilterNormalization` mode to support the new continuous-convolution boundary behavior without changing `dr.resample()`.
- Updated the Python binding for `detail.Resampler` to map `boundary="normalize"` and `boundary="zero"` to the corresponding normalization modes.
- Implemented the discrete-kernel path in Python using Dr.Jit array operations over the flattened source buffer, with standard convolution kernel orientation.
- Kept zero-local-sum handling lazy in the discrete path: it uses Dr.Jit masks and `select()` instead of forcing a Python-side reduction before returning: When `boundary="normalize"` encounters a zero local kernel sum, the continuous and discrete paths handle this slightly differently. The continuous path reuses `detail.Resampler`'s existing behavior and raises an error when the local kernel weight sum is zero. The discrete path avoids a Python-side synchronization check on JIT backends; when the local valid kernel sum is zero, it skips the boundary rescaling at that position, which gives the same value as zero padding there.

### Tests

Updated `tests/test_resample.py` to cover the four main convolution paths:

- Continuous filter with `boundary="normalize"`;
- Continuous filter with `boundary="zero"`;
- Discrete 1D Dr.Jit array kernel with `boundary="normalize"`;
- Discrete 1D Dr.Jit array kernel with `boundary="zero"`.

Additional coverage includes:

- Non-symmetric discrete kernels to verify convolution direction;
- JIT backend coverage for the discrete-kernel path;
- Validation that the discrete-kernel overload only accepts 1D Dr.Jit arrays, including rejection of Dr.Jit tensors and Python lists;
- Discrete convolution over selected tensor source axes.
