### PR TITLE
Butterfly warp-reduction for packet scatter-reduce

### DIFF
--- a/include/drjit/util.h
+++ b/include/drjit/util.h
@@ -353,4 +353,43 @@ void gather_packet_dynamic(size_t packet_size, Source &&source, const Index &ind
     }
 }
 
+/// Special handling of packet scatter-reductions when packet size is only known at runtime
+template <typename Target, typename Value, typename Index, typename Mask>
+void scatter_reduce_packet_dynamic(ReduceOp op, size_t packet_size, Target &target,
+    const Value *values, const Index &index, const Mask &mask_ = true,
+    ReduceMode mode = ReduceMode::Auto) {
+
+    // Broadcast mask to match shape of Index
+    mask_t<plain_t<Index>> mask = mask_;
+
+    auto default_scatter = [&]{
+        for (size_t i = 0; i < packet_size; ++i)
+            scatter_reduce(op, target, values[i],
+                fmadd(index, (uint32_t) packet_size, (uint32_t) i), mask, mode);
+    };
+
+    if constexpr (is_jit_v<Value>) {
+        if ((packet_size & (packet_size - 1)) == 0 && packet_size > 1) {
+            uint64_t *src_indices = (uint64_t *) alloca(
+                sizeof(uint64_t) * packet_size);
+            for (size_t i = 0; i < packet_size; ++i)
+                src_indices[i] = values[i].index_combined();
+
+            uint64_t new_index = ad_var_scatter_packet(packet_size,
+                target.index_combined(),
+                src_indices,
+                index.index(),
+                mask.index(),
+                op,
+                mode);
+
+            target = Target::steal((typename Target::Index) new_index);
+        } else {
+            default_scatter();
+        }
+    } else {
+        default_scatter();
+    }
+}
+
 NAMESPACE_END(drjit)

--- a/tests/test_memop.py
+++ b/tests/test_memop.py
@@ -1140,10 +1140,12 @@ def test37_take_multiple(t):
 
 @pytest.mark.parametrize("packet_size", [1, 2, 3, 4, 5, 6, 12, 16])
 @pytest.mark.parametrize("reduce_op", ["Add", "Mul", "Max", "Min"])
+@pytest.mark.parametrize("mode", [dr.ReduceMode.Local, dr.ReduceMode.Direct,
+                                  dr.ReduceMode.Auto])
 @pytest.skip_on(RuntimeError, "backend does not support the requested type of atomic reduction")
 @pytest.test_arrays("is_jit, float, shape=(*)")
 @pytest.mark.parametrize("force_optix", [True, False])
-def test35_scatter_packet_reduce(t, reduce_op, packet_size, force_optix):
+def test35_scatter_packet_reduce(t, reduce_op, packet_size, force_optix, mode):
     """
     Tests that packeted scatter reduce operations behave correctly.
     """
@@ -1189,7 +1191,7 @@ def test35_scatter_packet_reduce(t, reduce_op, packet_size, force_optix):
 
             op = getattr(dr.ReduceOp, reduce_op)
 
-            dr.scatter_reduce(op, target, src, index, active=active)
+            dr.scatter_reduce(op, target, src, index, mode=mode, active=active)
 
             dr.kernel_history_clear()
             dr.eval(target)
@@ -1219,6 +1221,12 @@ def test35_scatter_packet_reduce(t, reduce_op, packet_size, force_optix):
             )
 
     assert dr.allclose(target, ref)
+
+    # On LLVM, explicit Local/Direct fall back to per-element atomic scatter
+    # (no packet IR to assert against).
+    if (dr.backend_v(t) is dr.JitBackend.LLVM and
+            mode != dr.ReduceMode.Auto):
+        return
 
     # Test that we are actually using vector instructions on CUDA and LLVM
     if dr.backend_v(t) is dr.JitBackend.Metal:


### PR DESCRIPTION
Adds `scatter_reduce_packet_dynamic`, the runtime-N analogue of `gather_packet_dynamic`. 