### PR TITLE
Several bug fixes in the drjit-core

### DIFF
--- a/tests/test_coop_vec.py
+++ b/tests/test_coop_vec.py
@@ -57,6 +57,19 @@ def test03_add_min_max_fma(t, size):
     dr.schedule(r0, r1)
     assert r0 == 36 and r1 == 49
 
+    # FMA literal shortcuts.
+    a = nn.CoopVec(t(2), t(3))
+    b = nn.CoopVec(t(5), t(7))
+    c = nn.CoopVec(t(11), t(13))
+    ones = nn.CoopVec(t(1), t(1))
+    zeros = nn.CoopVec(t(0), t(0))
+
+    r0, r1 = dr.fma(ones, b, c)          # b + c
+    assert r0 == 16 and r1 == 20
+    r0, r1 = dr.fma(a, b, zeros)         # a * b
+    assert r0 == 10 and r1 == 21
+    r0, r1 = dr.fma(a, zeros, c)         # c
+    assert r0 == 11 and r1 == 13
 
 @pytest.mark.parametrize('sub_slice', [False, True])
 @pytest.test_arrays('jit,float16,shape=(*),-diff')

--- a/tests/test_memop.py
+++ b/tests/test_memop.py
@@ -1497,3 +1497,64 @@ def test42_masked_gather_loop(t, mode):
     # Lane 2: outputs 0 because the gather on buf_1 masked it
 
     assert dr.all(out == [0, 5, 0], axis=None)
+
+@pytest.test_arrays('uint32,shape=(*),jit')
+def test43_scatter_gather_power_of_two_indices(t):
+    N = 1 << 30
+    K = 30
+
+    idx = t([1 << i for i in range(K)])
+    idx = dr.repeat(idx, 2)
+    value = dr.arange(t, 1, K + 1)
+    value = dr.repeat(value, 2)
+
+    # dr.scatter / dr.gather round-trip
+    buf = dr.empty(t, N)
+    dr.scatter(buf, value=0, index=idx)
+    dr.eval(buf)
+
+    dr.scatter(buf, value=value, index=idx)
+    dr.eval(buf)
+    result = dr.gather(t, buf, idx)
+    assert dr.all(result == value)
+
+    # # dr.scatter_reduce(Add)
+    buf_red = dr.empty(t, N)
+    dr.scatter(buf_red, value=0, index=idx)
+    dr.eval(buf_red)
+
+    dr.scatter_reduce(dr.ReduceOp.Add, buf_red, value=value, index=idx)
+    dr.eval(buf_red)
+    result = dr.gather(t, buf_red, idx)
+    assert dr.all(result == 2 * value)
+
+    # dr.scatter_inc
+    buf_inc = dr.empty(t, N)
+    dr.scatter(buf_inc, value=0, index=idx)
+    dr.eval(buf_inc)
+
+    offs = dr.scatter_inc(buf_inc, idx)
+    assert dr.sum(offs) == K
+    result = dr.gather(t, buf_inc, idx)
+    assert dr.all(result == 2)
+
+    # dr.scatter_exch
+    buf_exch = dr.empty(t, N)
+    dr.scatter(buf_exch, value=idx, index=idx)
+    dr.eval(buf_exch)
+
+    old = dr.scatter_exch(buf_exch, value=42, index=idx)
+    dr.eval(old, buf_exch)
+    assert dr.all((old == idx) | (old == 42))
+    assert dr.all(dr.gather(t, buf_exch, idx) == 42)
+
+    # dr.scatter_cas
+    buf_cas = dr.empty(t, N)
+    dr.scatter(buf_cas, value=value, index=idx)
+    dr.eval(buf_cas)
+
+    old, swapped = dr.scatter_cas(buf_cas, compare=value, value=42, index=idx)
+    dr.eval(old, swapped, buf_cas)
+    assert dr.all((old == value) | (old == 42))
+    assert dr.sum(t(swapped)) == K
+    assert dr.all(dr.gather(t, buf_cas, idx) == 42)

--- a/tests/test_memop.py
+++ b/tests/test_memop.py
@@ -1498,18 +1498,19 @@ def test42_masked_gather_loop(t, mode):
 
     assert dr.all(out == [0, 5, 0], axis=None)
 
-@pytest.test_arrays('uint32,shape=(*),jit')
+@pytest.test_arrays('uint32,-diff,shape=(*),jit')
 def test43_scatter_gather_power_of_two_indices(t):
-    N = 1 << 30
-    K = 30
+    N = (1 << 28) + 1
 
-    idx = t([1 << i for i in range(K)])
-    idx = dr.repeat(idx, 2)
-    value = dr.arange(t, 1, K + 1)
-    value = dr.repeat(value, 2)
+    idx_list = [0] + [1 << (2 * i) for i in range(15)]
+    K = len(idx_list)
+
+    idx = dr.tile(t(idx_list), 2)
+    value = dr.tile(dr.arange(t, 1, K + 1), 2)
+
+    buf = dr.empty(t, N)
 
     # dr.scatter / dr.gather round-trip
-    buf = dr.empty(t, N)
     dr.scatter(buf, value=0, index=idx)
     dr.eval(buf)
 
@@ -1518,43 +1519,39 @@ def test43_scatter_gather_power_of_two_indices(t):
     result = dr.gather(t, buf, idx)
     assert dr.all(result == value)
 
-    # # dr.scatter_reduce(Add)
-    buf_red = dr.empty(t, N)
-    dr.scatter(buf_red, value=0, index=idx)
-    dr.eval(buf_red)
+    # dr.scatter_reduce(Add)
+    dr.scatter(buf, value=0, index=idx)
+    dr.eval(buf)
 
-    dr.scatter_reduce(dr.ReduceOp.Add, buf_red, value=value, index=idx)
-    dr.eval(buf_red)
-    result = dr.gather(t, buf_red, idx)
+    dr.scatter_reduce(dr.ReduceOp.Add, buf, value=value, index=idx)
+    dr.eval(buf)
+    result = dr.gather(t, buf, idx)
     assert dr.all(result == 2 * value)
 
     # dr.scatter_inc
-    buf_inc = dr.empty(t, N)
-    dr.scatter(buf_inc, value=0, index=idx)
-    dr.eval(buf_inc)
+    dr.scatter(buf, value=0, index=idx)
+    dr.eval(buf)
 
-    offs = dr.scatter_inc(buf_inc, idx)
+    offs = dr.scatter_inc(buf, idx)
     assert dr.sum(offs) == K
-    result = dr.gather(t, buf_inc, idx)
+    result = dr.gather(t, buf, idx)
     assert dr.all(result == 2)
 
     # dr.scatter_exch
-    buf_exch = dr.empty(t, N)
-    dr.scatter(buf_exch, value=idx, index=idx)
-    dr.eval(buf_exch)
+    dr.scatter(buf, value=idx, index=idx)
+    dr.eval(buf)
 
-    old = dr.scatter_exch(buf_exch, value=42, index=idx)
-    dr.eval(old, buf_exch)
+    old = dr.scatter_exch(buf, value=42, index=idx)
+    dr.eval(old, buf)
     assert dr.all((old == idx) | (old == 42))
-    assert dr.all(dr.gather(t, buf_exch, idx) == 42)
+    assert dr.all(dr.gather(t, buf, idx) == 42)
 
     # dr.scatter_cas
-    buf_cas = dr.empty(t, N)
-    dr.scatter(buf_cas, value=value, index=idx)
-    dr.eval(buf_cas)
+    dr.scatter(buf, value=value, index=idx)
+    dr.eval(buf)
 
-    old, swapped = dr.scatter_cas(buf_cas, compare=value, value=42, index=idx)
-    dr.eval(old, swapped, buf_cas)
+    old, swapped = dr.scatter_cas(buf, compare=value, value=42, index=idx)
+    dr.eval(old, swapped, buf)
     assert dr.all((old == value) | (old == 42))
     assert dr.sum(t(swapped)) == K
-    assert dr.all(dr.gather(t, buf_cas, idx) == 42)
+    assert dr.all(dr.gather(t, buf, idx) == 42)

--- a/tests/test_while_loop.py
+++ b/tests/test_while_loop.py
@@ -833,3 +833,20 @@ def test36_aliased_state_ad_fwd(t, mode):
     dr.forward_to(acc)
     assert dr.allclose(acc, 16)
     assert dr.allclose(dr.grad(acc), 32)
+
+@pytest.mark.parametrize('mode', ['evaluated', 'symbolic'])
+@pytest.test_arrays('uint32,is_jit,shape=(*)')
+@dr.syntax
+def test37_loop_multi_size_side_effects(t, mode):
+    big   = dr.zeros(t, 200)
+    small = dr.zeros(t, 4)
+    dr.make_opaque(big, small)
+
+    i = t(0)
+    while dr.hint(i < 1, mode=mode):
+        dr.scatter(big,   dr.arange(t, 100) + 1, dr.arange(t, 100))  # size 100
+        dr.scatter(small, t(42), t(0))                               # size 1
+        i += 1
+
+    assert dr.sum(big)[0] == 5050
+    assert small[0] == 42


### PR DESCRIPTION
This PR bumps the drjit-core submodule to pick up a series of bug fixes, and adds regression tests for several of them.
Currently, the only included tests cover logical bugs. This keeps the tests concise, but I'm happy to add tests for any of them before this gets merged.

---

### drjit-core [`c8c9c2d`](https://github.com/mitsuba-renderer/drjit-core/commit/c8c9c2d), test [`0013685a`](https://github.com/mitsuba-renderer/drjit/commit/0013685a)

scatter_inc: fix peer-match pointer hash (shl to shr). We convert the 64-bit pointer to 32 bits in order to use match.any.sync.b32, but in this case the typo used the left shift, which would make the offset bigger than 2^28 and start overlapping with the start of the array.

```python
# requires roughly 1 GiB of GPU memory
import drjit as dr
from drjit.cuda import UInt32
c = dr.zeros(UInt32, (1 << 28) + 1)
idx = UInt32([0 if i % 2 == 0 else (1 << 28) for i in range(64)])
dr.scatter_inc(c, idx)
dr.eval(c)
print(int(c[0]), int(c[1 << 28]))
```

---

### drjit-core [`955ea2f`](https://github.com/mitsuba-renderer/drjit-core/commit/955ea2f)

scatter_{exch,cas}: fix address stride for non u32 values. The byte stride for the target address was being computed from the index type (always 4 bytes) instead of the value type, so any non 4 byte value was scattered to the wrong slot.

```python
import drjit as dr
from drjit.cuda import UInt64, UInt32
target = dr.zeros(UInt64, 8)
dr.scatter_exch(target, UInt64(99), UInt32(4))
dr.eval(target)
print(list(target))
```

---

### drjit-core [`7f97a64`](https://github.com/mitsuba-renderer/drjit-core/commit/7f97a64)

local memory: fix masked read for bool/8 bit types. The default initialization of the result register for masked off lanes used `mov.b1` or `mov.b8`, which do not exist in PTX, and the LLVM path had a matching type mismatch and a name collision between the read and write intermediates.

```python
# A prior Bool write is needed to leave %w0=1 in the register; pre fix
# the masked off lane then reads that stale 1 instead of False.
import drjit as dr
from drjit.cuda import Bool, UInt32
s = dr.alloc_local(Bool, 4, value=Bool(True, True))
s.write(Bool(True, True), UInt32(0, 0), Bool(True, True))
mask = UInt32(0, 1) > 0   # lane 0 = False, lane 1 = True
got = s.read(UInt32(1, 1), mask)
dr.eval(got)
print([bool(got[k]) for k in range(2)])   # pre fix: [True, True], post fix: [False, True]
```

---

### drjit-core [`fa4597d`](https://github.com/mitsuba-renderer/drjit-core/commit/fa4597d), test [`72f2c38f`](https://github.com/mitsuba-renderer/drjit/commit/72f2c38f)

coop_vec: fix fma zero shortcut for `fma(a, b, 0)`. The shortcut branch was guarded on the second operand being zero instead of the third operand.

```python
import drjit as dr, drjit.nn as nn
from drjit.cuda import Float
a = nn.CoopVec(Float(2), Float(3))
z = nn.CoopVec(Float(0), Float(0))
c = nn.CoopVec(Float(11), Float(13))
r0, r1 = dr.fma(a, z, c)
dr.eval(r0, r1)
print(list(r0)[0], list(r1)[0])   # pre fix: 0.0 0.0, post fix: 11.0 13.0
```

---

### drjit-core [`ce486d1`](https://github.com/mitsuba-renderer/drjit-core/commit/ce486d1)

coop_vec: fix ternary op type check typo (a1 to a2). The type validator checked `a0->type != a1->type` twice instead of also checking `a2`, so a third argument with a different type slipped through silently.

```python
import drjit as dr, drjit.nn as nn
from drjit.cuda import Float, Float16
a = nn.CoopVec(Float(1), Float(2))
b = nn.CoopVec(Float(1), Float(2))
c = nn.CoopVec(Float16(1), Float16(2))
try:
    dr.fma(a, b, c)
    print("pre fix: no error raised")
except RuntimeError as e:
    print(f"post fix: {e}")
```

---

### drjit-core [`523d49b`](https://github.com/mitsuba-renderer/drjit-core/commit/523d49b)

cuda_tex: fix memset size for `CUDA_MEMCPY3D` d2t path. The struct was being zeroed with `sizeof(CUDA_MEMCPY2D)` instead of `sizeof(CUDA_MEMCPY3D)`,

```python
import drjit as dr
from drjit.cuda import Float, TensorXf, Texture3f
tex = Texture3f((4, 4, 4), 1)
tex.set_tensor(TensorXf(dr.arange(Float, 64), (4, 4, 4, 1)))
print(tex.eval((0.5, 0.5, 0.5)))
```

---

### drjit-core [`7a96a60`](https://github.com/mitsuba-renderer/drjit-core/commit/7a96a60)

cuda: uint8/int8 for `min`, `max`, `div`, and `mod`. These ops were missing from the `jitc_int8_unsupported` list.

```python
import drjit as dr
from drjit.cuda import UInt8
r = dr.minimum(UInt8(5, 7, 3), UInt8(4, 4, 4))
dr.eval(r)
print(list(r))
```

---

### drjit-core [`bfe874f`](https://github.com/mitsuba-renderer/drjit-core/commit/bfe874f), test [`2097469e`](https://github.com/mitsuba-renderer/drjit/commit/2097469e)

loop: fix side effect size scan to walk the list. The size scan inside `jitc_var_loop_end` was reading `se_list.back()` on every iteration instead of indexing the list, so only the last side effect contributed to the kernel size.

```python
import drjit as dr
from drjit.cuda import UInt32
big   = dr.zeros(UInt32, 200); dr.make_opaque(big)
small = dr.zeros(UInt32, 4);   dr.make_opaque(small)
@dr.syntax
def f():
    i = UInt32(0)
    while i < 1:
        dr.scatter(big,   dr.arange(UInt32, 100), dr.arange(UInt32, 100))
        dr.scatter(small, UInt32(42), UInt32(0))
        i += 1
f()
```

---

### drjit-core [`7370ca6`](https://github.com/mitsuba-renderer/drjit-core/commit/7370ca6)

op: avoid UB for literal integer div and mod. The literal folding path applied the host C++ `/` and `%` operators directly, which is undefined behavior for divide by zero and produced a SIGFPE. We decided to follow the CUDA semantics in this case.

```python
import drjit as dr
from drjit.cuda import Int32
r = Int32(7) // Int32(0)
dr.eval(r)
print(r[0])   # pre fix: SIGFPE (process crash), post fix: -1
```

---

### drjit-core [`0d40178`](https://github.com/mitsuba-renderer/drjit-core/commit/0d40178)

scatter_inc: return 0 for masked off lanes. Two parts: the CUDA runtime mask path left the result register uninitialized on masked off lanes, and the literal mask shortcut returned `UINT32_MAX`.

```python
import drjit as dr
from drjit.cuda import UInt32, Bool
c_lit = dr.zeros(UInt32, 4)
c_rt  = dr.zeros(UInt32, 4)
dr.eval(c_lit, c_rt)
offs_lit = dr.scatter_inc(c_lit, UInt32(0, 0, 0, 0), False)
offs_rt  = dr.scatter_inc(c_rt,  UInt32(0, 0, 0, 0), Bool(False, False, False, False))
dr.eval(offs_lit, offs_rt)
print(list(offs_lit), list(offs_rt))
# pre fix: [4294967295,4294967295,4294967295,4294967295] vs stale (e.g. [3,3,3,3])
# post fix: [0,0,0,0] [0,0,0,0]
```
