### PR TITLE
Fix aliased loop state variables in ``dr.while_loop()``

### DIFF
--- a/src/extra/loop.cpp
+++ b/src/extra/loop.cpp
@@ -77,16 +77,6 @@ static bool ad_loop_symbolic(JitBackend backend, const char *name,
         indices1.release();
         indices2.clear();
 
-        // Read back the indices to update the loop state variables
-        // This is necessary to catch cases where a variable is added to the
-        // loop state twice.
-        read_cb(payload, indices1);
-        for (uint64_t i : indices1)
-            indices2.push_back((uint32_t) i);
-        jit_var_loop_update_inner_in(loop.index(), indices2.data());
-        indices1.release();
-        indices2.clear();
-
         do {
             // Evaluate the loop condition
             uint32_t active_initial = cond_cb(payload);

--- a/src/python/while_loop.cpp
+++ b/src/python/while_loop.cpp
@@ -14,6 +14,7 @@
 #include "detail.h"
 #include "tracker.h"
 #include "shape.h"
+#include "apply.h"
 #include <nanobind/stl/optional.h>
 
 /**
@@ -36,6 +37,8 @@ struct LoopState {
     VariableTracker tracker;
 
     size_t active_size;
+    /// Has the alias-free working copy of 'state' been built yet?
+    bool dealiased = false;
 
     LoopState(nb::tuple &&state, nb::callable &&cond, nb::callable &&body,
               dr::vector<dr::string> &&labels, bool strict, bool check_size)
@@ -96,6 +99,26 @@ static void while_loop_read_cb(void *p, dr::vector<uint64_t> &indices) {
     nb::gil_scoped_acquire guard;
     LoopState *ls = (LoopState *) p;
     ls->tracker.read(ls->state, indices, ls->labels);
+
+    // On the first read, replace the live state with an alias-free working copy.
+    // (sharing the same indices). We will later revert this copy for state fields
+    // that have not been modified.
+    if (!ls->dealiased) {
+        struct DealiasShareOp : TransformCallback {
+            void operator()(nb::handle h1, nb::handle h2) override {
+                const ArraySupplement &s = supp(h1.type());
+                if ((JitBackend) s.backend == JitBackend::None)
+                    nb::inst_replace_copy(h2, h1);
+                else
+                    s.reset_index(s.index(inst_ptr(h1)), inst_ptr(h2));
+            }
+        };
+
+        DealiasShareOp op;
+        ls->state = nb::borrow<nb::tuple>(transform("drjit.while_loop.dealias", op, ls->state));
+        ls->dealiased = true;
+    }
+
     ls->tracker.verify_size(ls->active_size);
 }
 

--- a/tests/test_while_loop.py
+++ b/tests/test_while_loop.py
@@ -771,3 +771,65 @@ def test33_tensor_loop_ad(t, mode):
     dr.backward(y)
     assert x.grad.shape == (3,)
     assert dr.allclose(x.grad, t([10, 10, 10]))
+
+
+@pytest.mark.parametrize('mode', ['evaluated', 'symbolic'])
+@pytest.mark.parametrize("optimize", [True, False])
+@pytest.test_arrays('float32,is_jit,shape=(*)')
+@dr.syntax
+def test34_aliased_state(t, mode, optimize):
+    # Check that aliases between loop state variables are handled correctly
+    UInt32 = dr.uint32_array_t(t)
+
+    with dr.scoped_set_flag(dr.JitFlag.OptimizeLoops, optimize):
+        x = dr.arange(t, 5) + 1
+        acc = x
+        i = UInt32(0)
+        while dr.hint(i < 3, mode=mode):
+            acc = acc * x
+            i += 1
+
+        dr.eval(acc, x)
+        assert dr.all(acc == x*x*x*x)
+        assert dr.all(x == dr.arange(t, 5) + 1)
+
+@pytest.mark.parametrize('mode', ['evaluated', 'symbolic'])
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@dr.syntax
+def test35_aliased_state_ad_bwd(t, mode):
+    # Test the same thing for reverse-mode AD
+    UInt32 = dr.uint32_array_t(dr.detached_t(t))
+
+    x = t(2)
+    dr.enable_grad(x)
+
+    acc = x
+    i = UInt32(0)
+    while dr.hint(i < 3, mode=mode, max_iterations=3):
+        acc = acc * x
+        i += 1
+
+    dr.backward(acc)
+    assert dr.allclose(acc, 16)
+    assert dr.allclose(dr.grad(x), 32)
+
+@pytest.mark.parametrize('mode', ['evaluated', 'symbolic'])
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@dr.syntax
+def test36_aliased_state_ad_fwd(t, mode):
+    # Test the same thing for forward-mode AD
+    UInt32 = dr.uint32_array_t(dr.detached_t(t))
+
+    x = t(2)
+    dr.enable_grad(x)
+    dr.set_grad(x, 1)
+
+    acc = x
+    i = UInt32(0)
+    while dr.hint(i < 3, mode=mode):
+        acc = acc * x
+        i += 1
+
+    dr.forward_to(acc)
+    assert dr.allclose(acc, 16)
+    assert dr.allclose(dr.grad(acc), 32)


### PR DESCRIPTION
When two state variable slots of ``dr.while_loop()`` referenced the same Python object, symbolic loop recording could produce malformed kernel or, worse, silently output incorrect results. This commit introduces a pass that temporarily replaces the loop state with a de-aliased copy to avoid this issue.