### PR TITLE
Disable JAX GPU preallocation in tests

### DIFF
--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 
 import drjit as dr
@@ -31,6 +32,8 @@ except ImportError:
     pass
 
 try:
+    # Disable jax's greedy preallocation of the GPU memory
+    os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
     import jax
     from jax import config
     config.update("jax_enable_x64", True) # Enable double precision


### PR DESCRIPTION
JAX preallocate most of the GPU by default, starving the cuda backend so the cuda wrap tests fail with out of memory. Disable it via XLA_PYTHON_CLIENT_PREALLOCATE=false
https://docs.jax.dev/en/latest/gpu_memory_allocation.html