### PR TITLE
Accelerate Dr.Jit tracing, code generation, and Python bindings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,9 +37,10 @@ of embarrassingly parallel computation.
   that an addition will be needed at some later point by recording it into a
   graph representation (this is called *tracing*). Eventually, it will
   *just-in-time* (JIT) compile the recorded operations into a *fused* kernel
-  using either `LLVM <https://en.wikipedia.org/wiki/LLVM>`_ (when targeting the
-  CPU) or `CUDA <https://en.wikipedia.org/wiki/CUDA>`_ (when targeting the
-  GPU). The values ``a`` and ``b`` will typically be arrays with many elements,
+  using `LLVM <https://en.wikipedia.org/wiki/LLVM>`_ (when targeting the CPU),
+  `CUDA <https://en.wikipedia.org/wiki/CUDA>`_ (when targeting NVIDIA GPUs), or
+  `Metal <https://developer.apple.com/metal/>`_ (when targeting Apple Silicon
+  GPUs). The values ``a`` and ``b`` will typically be arrays with many elements,
   and the system parallelizes their evaluation using multi-core parallelism and
   vector instruction sets like `AVX512
   <https://en.wikipedia.org/wiki/AVX-512>`_ or `ARM Neon

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,17 @@ DrJit 1.4.0 (TBA)
 
 **New Features**
 
+- **Metal Backend**: Dr.Jit can now target Apple Silicon GPUs (M1 or newer)
+  through a new Metal backend. The backend generates `Metal Shading Language
+  <https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf>`__
+  kernels but requires no separate SDK beyond a recent version of macOS. It
+  supports the full range of Dr.Jit features including symbolic control flow,
+  automatic differentiation, hardware-accelerated and writable textures, ray
+  tracing, :ref:`cooperative vectors <coop_vec>`, and reductions. Apple GPUs
+  lack double precision ALUs, hence double precision arithmetic generates a
+  warning an is then demoted to single precision. (contributed by `Sébastien
+  Speierer <https://github.com/Speierers>`__).
+
 - **Matrix Multiplication for Tensors**: The ``@`` operator and
   :py:func:`dr.matmul() <matmul>` now accept Dr.Jit tensors of any dimension
   and shape, fully replicating NumPy / PyTorch ``matmul`` semantics including

--- a/docs/coop_vec.rst
+++ b/docs/coop_vec.rst
@@ -21,7 +21,7 @@ within larger programs while fully *fusing* all steps of the process into a
 single kernel. Other workloads that heavily rely on matrix-vector products may
 benefit as well.
 
-Dr.Jit supports cooperative vectors on both of its backends:
+Dr.Jit supports cooperative vectors on all of its backends:
 
 - On **NVIDIA GPUs (Turing or newer)**, cooperative vectors map to the OptiX
   `cooperative vector API
@@ -29,6 +29,12 @@ Dr.Jit supports cooperative vectors on both of its backends:
   leveraging built-in `tensor cores
   <https://www.nvidia.com/en-us/data-center/tensor-cores/>`__ for acceleration.
   Driver version R570 or newer is required to use this feature.
+
+- On **Apple Silicon GPUs (M1 or newer)**, cooperative vectors are evaluated by
+  the Metal backend. Both half- and single-precision matrices are supported.
+  Dedicated matrix-multiplication hardware (available on M5 and newer GPUs in
+  combination with Metal 4) only accelerates half precision; single-precision
+  products and earlier hardware run on the GPU's general-purpose pipeline.
 
 - On the **CPU (LLVM) backend**, compilation of cooperative vector operations
   targets the available instruction set extensions (AVX512, NEON, etc.).
@@ -159,8 +165,9 @@ Cooperative vectors support a restricted set of arithmetic operations:
 - :py:func:`dr.step() <step>`.
 - :py:func:`nn.matvec() <drjit.nn.matvec>`
 
-These operations directly map to hardware-optimized operations on CUDA/OptiX.
-Operations outside of this set can be realized via unpacking/repacking, e.g.:
+These operations directly map to hardware-optimized operations on the
+CUDA/OptiX and Metal backends. Operations outside of this set can be realized
+via unpacking/repacking, e.g.:
 
 .. code-block::
 
@@ -314,6 +321,11 @@ Performance considerations
 
     Unpacking cooperative vectors may degrade performance. It is best to keep
     them in their opaque layout whenever possible.
+
+- **Metal** backend:
+
+  - Matrices passed to :py:func:`nn.matvec() <drjit.nn.matvec>` must be in the
+    densely-packed layout produced by :py:func:`nn.pack() <drjit.nn.pack>`.
 
 - **LLVM** backend:
 

--- a/docs/eval.rst
+++ b/docs/eval.rst
@@ -273,6 +273,10 @@ to the user's home directory):
    - **Linux**: ``~/.drjit/optix7cache.db``
    - **Windows**: ``~\AppData\Local\Temp\drjit\optix7cache.db``
 
+The Metal backend does not currently persist compiled kernels to disk. Its
+kernels are retained in an in-memory cache that benefits repeated computation
+within a session, but a new session always recompiles them from scratch.
+
 Analyzing JIT behavior
 ----------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -36,8 +36,8 @@ using the decorator discussed in the section on :ref:`interoperability
 <interop>`. It is worth noting that this isn't a great solution since evaluated
 mode comes at a significant additional cost.
 
-Will you add a Metal/ROCm/.. backend?
--------------------------------------
+Will you add a Vulkan/DirectX/ROCm/.. backend?
+----------------------------------------------
 
 We may add further backends in the future, but doing so currently does not have
 a high priority on our TODO list---external contributions are welcome!

--- a/docs/optim.rst
+++ b/docs/optim.rst
@@ -43,10 +43,10 @@ You can use the functions :py:func:`drjit.thread_count`,
 :py:func:`drjit.set_thread_count` to specify the number of threads used for
 parallel processing.
 
-On the CUDA backend, the system automatically determines a number of *threads*
-that maximize occupancy along with a suitable number of *blocks* and then
-launches a parallel program that spreads out over the entire GPU (assuming that
-there is enough work to do so).
+On the GPU backends (CUDA and Metal), the system automatically determines a
+number of *threads* that maximize occupancy along with a suitable number of
+*blocks* and then launches a parallel program that spreads out over the entire
+GPU (assuming that there is enough work to do so).
 
 .. _cow:
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -27,12 +27,14 @@ the various available array types.
 Backends
 --------
 
-Dr.Jit types are organized into five different *backend*-specific Python
+Dr.Jit types are organized into seven different *backend*-specific Python
 packages named
 
 - :py:mod:`drjit.scalar`,
 - :py:mod:`drjit.cuda`,
 - :py:mod:`drjit.cuda.ad`,
+- :py:mod:`drjit.metal`,
+- :py:mod:`drjit.metal.ad`,
 - :py:mod:`drjit.llvm`, and
 - :py:mod:`drjit.llvm.ad`.
 
@@ -44,7 +46,7 @@ one of the above depending on the backends detected at runtime.
 - :py:mod:`drjit.auto`, and
 - :py:mod:`drjit.auto.ad`.
 
-Any given array type (e.g. ``Array3f``) actually exists in *all five* of these
+Any given array type (e.g. ``Array3f``) actually exists in *all seven* of these
 packages (e.g., :py:class:`drjit.scalar.Array3f`, :py:class:`drjit.llvm.ad.Array3f`). However,
 there are notable differences between them:
 
@@ -77,6 +79,13 @@ there are notable differences between them:
   <https://docs.nvidia.com/cuda/parallel-thread-execution/index.html>`__. This
   backend only depends on users having a suitable graphics card and driver
   (notably, users do not need to install the CUDA SDK.)
+
+  The Metal backend launches parallel kernels on Apple Silicon GPUs (M1 or
+  newer) by generating `Metal Shading Language
+  <https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf>`__
+  source code. It only requires a recent version of macOS. Apple GPUs have no
+  hardware double-precision support, so ``Float64`` is transparently
+  computed in single precision on this backend.
 
 - **Automatic differentiation**: types within packages having the ``.ad`` suffix
   additionally track differentiable operations to enable subsequent forward- or

--- a/docs/what.rst
+++ b/docs/what.rst
@@ -245,14 +245,20 @@ very general programs to a given task or dataset to improve performance.
 Backends
 --------
 
-Dr.Jit provides two backends with feature parity:
+Dr.Jit provides three backends with feature parity:
 
 1. The `CUDA <https://en.wikipedia.org/wiki/CUDA>`__ backend targets `NVIDIA
    <https://www.nvidia.com>`__ GPUs with compute capability 5.0 or newer.
    You can explicitly request this backend by importing types from
    ``drjit.cuda`` or ``drjit.cuda.ad`` (add ``.ad`` if derivative computation is needed).
 
-2. The `LLVM <https://llvm.org>`__ backend targets Intel (``x86_64``) and ARM
+2. The `Metal <https://developer.apple.com/metal/>`__ backend targets Apple
+   Silicon GPUs (M1 or newer) using the Metal Shading Language. You can
+   explicitly request this backend by importing types from ``drjit.metal`` or
+   ``drjit.metal.ad`` (add ``.ad`` if derivative computation is needed). This
+   backend only requires a recent version of macOS.
+
+3. The `LLVM <https://llvm.org>`__ backend targets Intel (``x86_64``) and ARM
    (``aarch64``) CPUs. It parallelizes the program using the available CPU
    cores and vector instruction set extensions such as AVX, AVX512, NEON, etc.
    You can explicitly request this backend by importing types from
@@ -280,8 +286,8 @@ Dr.Jit provides two backends with feature parity:
      <https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.6/LLVM-18.1.6-win64.exe>`__.
 
 The previously mentioned ``drjit.auto`` and ``drjit.auto.ad`` backends redirect
-to the CUDA backend if a compatible GPU was found, otherwise they fall back to
-the LLVM backend.
+to a GPU backend if a compatible device was found (Metal on Apple Silicon, CUDA
+on NVIDIA hardware), otherwise they fall back to the LLVM backend.
 
 Other backends may be added in the future.
 

--- a/include/drjit/python.h
+++ b/include/drjit/python.h
@@ -85,7 +85,7 @@ NAMESPACE_BEGIN(drjit)
  * representation.
  */
 struct ArrayMeta {
-    uint32_t backend       : 3; // 3 bits to accommodate JitBackend::Metal (= 4)
+    uint32_t backend       : 2;
     uint32_t type          : 4;
     uint32_t ndim          : 3;
     uint32_t is_vector     : 1;
@@ -102,10 +102,7 @@ struct ArrayMeta {
     uint8_t shape[4];
 };
 
-// 33 bits of bit-fields span two uint32_t storage units (8 bytes), plus 4
-// bytes of 'shape' = 12 bytes total. Bumped from 8 bytes when 'backend' was
-// widened from 2 to 3 bits to accommodate JitBackend::Metal (= 4).
-static_assert(sizeof(ArrayMeta) == 12, "Structure packing issue");
+static_assert(sizeof(ArrayMeta) == 8, "Structure packing issue");
 
 /// A large set of Dr.Jit operations are handled generically. This
 /// enumeration encodes indices into the ArraySupplement::op field

--- a/include/drjit/quaternion.h
+++ b/include/drjit/quaternion.h
@@ -291,7 +291,8 @@ Array<Value, 3> quat_to_euler(const Quaternion<Value> &q) {
     // https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
 
     // Clamp the result to stay in the valid range for asin
-    Value sinp = clip(2 * fmsub(q.w(), q.y(), q.z() * q.x()), -1.0, 1.0);
+    Value sinp = clip(2 * fmsub(q.w(), q.y(), q.z() * q.x()),
+                      Value(-1.f), Value(1.f));
     mask_t<Value> gimbal_lock = abs(sinp) > (1.f - 5e-8f);
 
     // roll (x-axis rotation)

--- a/src/extra/autodiff.cpp
+++ b/src/extra/autodiff.cpp
@@ -4236,7 +4236,7 @@ Index ad_coop_vec_pack(uint32_t n, const Index *in) {
     for (uint32_t i = 0; i < n; ++i) {
         Index index = in[i];
         tmp[i] = jit_index(index);
-        attached |= ad_grad_enabled(index);
+        attached |= (bool) ad_grad_enabled(index);
     }
 
     JitVar result = JitVar::steal(jit_coop_vec_pack(n, tmp));

--- a/src/extra/call.cpp
+++ b/src/extra/call.cpp
@@ -197,21 +197,21 @@ static void ad_call_getter(JitBackend backend, const char *variant,
 
             uint32_t rv3_i = rv3[i+j*rv2.size()];
             if (!rv3_i) {
-                p->size = (int) tsize;
+                p->size = (int16_t) tsize;
                 p->src = 0;
             } else {
                 VarState state = jit_var_state(rv3_i);
 
                 switch (state) {
                     case VarState::Literal:
-                        p->size = (int) tsize;
+                        p->size = (int16_t) tsize;
                         p->src = 0;
                         jit_var_read(rv3_i, 0, &p->src);
                         break;
 
                     case VarState::Unevaluated:
                     case VarState::Evaluated:
-                        p->size = -(int) tsize;
+                        p->size = (int16_t) -(int) tsize;
                         cleanup.push_back(jit_var_data(rv3_i, (void **) &p->src));
                         break;
 

--- a/src/extra/loop.cpp
+++ b/src/extra/loop.cpp
@@ -195,7 +195,7 @@ static size_t ad_loop_evaluated_mask(JitBackend backend, const char *name,
 
         // Push the mask onto mask stack and execute the loop body
         {
-            uint32_t size = jit_var_size(active.index());
+            uint32_t size = (uint32_t) jit_var_size(active.index());
 
             JitVar it_mask;
             if (size != 1) {

--- a/src/extra/resample.cpp
+++ b/src/extra/resample.cpp
@@ -549,8 +549,8 @@ Array Resampler::Impl::forward(const Array &source, uint32_t stride) const {
     using UInt32 = uint32_array_t<Array>;
     using Int32  = int32_array_t<Array>;
 
-    const Accum &weights = get_weights<Accum>();
-    const Int32 &offset = get_offset<Int32>();
+    const Accum &weights_v = get_weights<Accum>();
+    const Int32 &offset_v = get_offset<Int32>();
 
     uint32_t source_size = (uint32_t) source.size(),
              n_passes = source_size / (source_res * stride),
@@ -559,12 +559,12 @@ Array Resampler::Impl::forward(const Array &source, uint32_t stride) const {
     UInt32 j, k, i_base;
     decompose(target_size, stride, j, k, i_base);
 
-    Boundary boundary = this->boundary;
+    Boundary boundary_v = this->boundary;
     int32_t R = (int32_t) source_res;
 
     Accum target = zeros<Accum>(target_size);
 
-    uint32_t taps = this->taps;
+    uint32_t taps_v = this->taps;
 
     if (!symbolic) {
         // Table-driven per-output accumulation (handles any boundary). Unrolled
@@ -573,15 +573,15 @@ Array Resampler::Impl::forward(const Array &source, uint32_t stride) const {
         // the interior branch.
         auto accum = [&](const UInt32 &ibase, const UInt32 &kk,
                          const UInt32 &jj) -> Accum {
-            Int32  offj = gather<Int32>(offset, jj);
-            UInt32 woff = jj * taps;
+            Int32  offj = gather<Int32>(offset_v, jj);
+            UInt32 woff = jj * taps_v;
             UInt32 soff = UInt32(
                 (Int32(ibase) + offj) * (int32_t) stride + Int32(kk));
             Accum acc = zeros<Accum>(target_size);
-            for (uint32_t l = 0; l < taps; ++l) {
-                Accum weight = gather<Accum>(weights, woff + l);
+            for (uint32_t l = 0; l < taps_v; ++l) {
+                Accum weight = gather<Accum>(weights_v, woff + l);
                 mask_t<UInt32> active;
-                UInt32 addr = tap_address(boundary, offj, l, soff, ibase, kk,
+                UInt32 addr = tap_address(boundary_v, offj, l, soff, ibase, kk,
                                           stride, R, active);
                 acc = fmadd(weight,
                             Accum(gather<Array>(source, addr, active)), acc);
@@ -603,7 +603,7 @@ Array Resampler::Impl::forward(const Array &source, uint32_t stride) const {
                     const UInt32 &jj) -> Accum {
                     UInt32 base = (ibase + UInt32(Int32(jj) - corg)) * stride + kk;
                     Accum acc = zeros<Accum>(target_size);
-                    for (uint32_t l = 0; l < taps; ++l)
+                    for (uint32_t l = 0; l < taps_v; ++l)
                         acc = fmadd(
                             Accum((scalar_t<Accum>) interior_weights[l]),
                             Accum(gather<Array>(source, base + l * stride)), acc);
@@ -618,8 +618,8 @@ Array Resampler::Impl::forward(const Array &source, uint32_t stride) const {
             target = accum(i_base, k, j);
         }
     } else {
-        Int32  offset_j = gather<Int32>(offset, j);
-        UInt32 weight_offset = j * taps;
+        Int32  offset_j = gather<Int32>(offset_v, j);
+        UInt32 weight_offset = j * taps_v;
         UInt32 source_offset = UInt32(
             (Int32(i_base) + offset_j) * (int32_t) stride + Int32(k));
 
@@ -627,15 +627,15 @@ Array Resampler::Impl::forward(const Array &source, uint32_t stride) const {
         tie(l, target) = while_loop(
             make_tuple(l, target),
             // Loop condition
-            [taps](const UInt32 &l, const Accum &) {
-                return l < taps;
+            [taps_v](const UInt32 &l, const Accum &) {
+                return l < taps_v;
             },
             // Loop body
-            [source_offset, source, weight_offset, weights, stride, boundary,
+            [source_offset, source, weight_offset, weights_v, stride, boundary_v,
              offset_j, i_base, k, R](UInt32 &l, Accum &target) {
-                Accum weight = gather<Accum>(weights, weight_offset + l);
+                Accum weight = gather<Accum>(weights_v, weight_offset + l);
                 mask_t<UInt32> active;
-                UInt32 addr = tap_address(boundary, offset_j, l, source_offset,
+                UInt32 addr = tap_address(boundary_v, offset_j, l, source_offset,
                                           i_base, k, stride, R, active);
                 target = fmadd(weight,
                                Accum(gather<Array>(source, addr, active)),

--- a/src/python/bind.cpp
+++ b/src/python/bind.cpp
@@ -178,11 +178,15 @@ nb::object bind(const ArrayBinding &b) {
         d.destruct = b.destruct;
     }
 
+    // Stash deallocated instances in a small pool to accelerate Dr.Jit array construction.
+    d.flags |= (uint32_t) nb::detail::type_flags::pooled;
+    d.pool_capacity = 128;
+
     d.align = b.talign;
     d.size = b.tsize_rel * b.talign;
     d.name = name.c_str();
     d.type = b.array_type;
-    d.supplement = (uint32_t) sizeof(ArraySupplement);
+    d.supplement_size = sizeof(ArraySupplement);
     d.scope = scope.ptr();
 
     PyType_Slot slots [] = {

--- a/src/python/dlpack.cpp
+++ b/src/python/dlpack.cpp
@@ -94,7 +94,7 @@ static nb::ndarray<> dlpack(nb::handle_t<ArrayBase> h, bool force_cpu, nb::handl
     if (s.is_tensor) {
         is_dynamic = true;
     } else {
-        for (int i = 0; i < s.ndim; ++i)
+        for (int i = 0; i < (int) s.ndim; ++i)
             is_dynamic |= s.shape[i] == DRJIT_DYNAMIC;
     }
 
@@ -198,7 +198,7 @@ static nb::ndarray<> dlpack(nb::handle_t<ArrayBase> h, bool force_cpu, nb::handl
             stride *= s.shape[i];
 
             // Special case: array containing 3D SIMD arrays which are 4D-aligned
-            if (i == s.ndim - 1 && s.talign == 16 && s.shape[i] == 3)
+            if (i == (int) s.ndim - 1 && s.talign == 16 && s.shape[i] == 3)
                 stride++;
 
             if (i == 0)

--- a/src/python/init.cpp
+++ b/src/python/init.cpp
@@ -159,17 +159,15 @@ int tp_init_array(PyObject *self, PyObject *args, PyObject *kwds) noexcept {
                         // Always broadcast when the element type is one of the sub-elements
                         // or its AD/non-AD counterpart
                         PyTypeObject *cur_tp = (PyTypeObject *) s.value;
-                        while (cur_tp) {
-                            ArrayMeta m_curr =  supp(cur_tp);
+                        while (cur_tp && is_drjit_type(cur_tp)) {
+                            const ArraySupplement &s_cur = supp(cur_tp);
+                            ArrayMeta m_curr = s_cur;
                             m_curr.is_diff = m_arg.is_diff;
-                            m_curr.talign = m_arg.talign;
                             if (m_curr == m_arg) {
                                 try_sequence_import = false;
                                 break;
                             }
-                            if (!is_drjit_type(cur_tp))
-                                break;
-                            cur_tp = (PyTypeObject *) supp(cur_tp).value;
+                            cur_tp = (PyTypeObject *) s_cur.value;
                         }
                     }
                 }

--- a/src/python/memop.cpp
+++ b/src/python/memop.cpp
@@ -856,7 +856,7 @@ nb::object unravel(const nb::type_object_t<ArrayBase> &dtype,
             if (shape_hint && (size_t) i < shape_hint->size()) {
                 // Use the provided shape hint for this dynamic dimension
                 shape[i] = (Py_ssize_t) (*shape_hint)[i];
-            } else if (i != s.ndim - 1) {
+            } else if (i != (int) s.ndim - 1) {
                 throw nb::type_error("drjit.unravel(): only the last dimension "
                                      "of 'dtype' may be dynamic!");
             } else {

--- a/src/python/meta.cpp
+++ b/src/python/meta.cpp
@@ -12,6 +12,10 @@
 #include "base.h"
 #include "../ext/nanobind/src/buffer.h"
 #include <nanobind/ndarray.h>
+#include <tsl/robin_map.h>
+#include <drjit-core/hash.h>
+#include <xxh3.h>
+#include <cstring>
 
 /// Check if the given metadata record is valid
 bool meta_check(ArrayMeta m) noexcept {
@@ -291,6 +295,41 @@ ArrayMeta meta_get_general(nb::handle h) noexcept {
     return m;
 }
 
+// Type promotion and type resolution accounts for a significant portion of
+// tracing cost in Dr.Jit Python code. Since this is a pure function of its
+// inputs, we can memoize the result into a cache to skip it in most cases.
+// The data structures below are protected by the GIL.
+struct PromoteKey {
+    PyTypeObject *tp[3];
+    uint32_t flags;
+    bool operator==(const PromoteKey &o) const {
+        return tp[0] == o.tp[0] && tp[1] == o.tp[1] &&
+               tp[2] == o.tp[2] && flags == o.flags;
+    }
+};
+struct PromoteKeyHasher {
+    size_t operator()(const PromoteKey &k) const {
+        // Specialized hash function for type promotion keys. See VariableKeyHasher
+        // in drjit-core for more details on the particular construction used here.
+        auto mix = [](uint64_t a, uint64_t b) -> uint64_t {
+            XXH128_hash_t r = XXH_mult64to128(a, b);
+            return r.low64 ^ r.high64;
+        };
+
+        uint64_t a = mix((uint64_t) (uintptr_t) k.tp[0] ^ PRIME64_1,
+                         (uint64_t) (uintptr_t) k.tp[1] ^ PRIME64_2);
+        uint64_t b = mix((uint64_t) (uintptr_t) k.tp[2] ^ PRIME64_3,
+                         (uint64_t) k.flags             ^ PRIME64_4);
+
+        return (size_t) mix(a ^ b, PRIME64_5);
+    }
+};
+struct PromoteVal { nb::handle h[3]; };
+
+static tsl::robin_map<PromoteKey, PromoteVal, PromoteKeyHasher,
+                      std::equal_to<PromoteKey>,
+                      std::allocator<std::pair<PromoteKey, PromoteVal>>,
+                      /* StoreHash = */ true> promote_cache;
 
 /**
  * \brief Given a list of Dr.Jit arrays and scalars, determine the flavor and
@@ -307,76 +346,132 @@ ArrayMeta meta_get_general(nb::handle h) noexcept {
  *    first operand will be promoted to a mask array
  */
 void promote(nb::object *o, size_t n, bool select) {
-    ArrayMeta m{}, mi[3];
-
     if (n > 3)
         nb::raise("promote(): too many arguments!");
 
-    nb::handle h;
+    PromoteKey key{};
+    bool cacheable = true;
     for (size_t i = 0; i < n; ++i) {
-        nb::handle o_i = o[i];
-        ArrayMeta m2 = meta_get(o_i);
+        nb::handle tp = o[i].type();
+        key.tp[i] = (PyTypeObject *) tp.ptr();
+        if (!is_drjit_type(tp) && key.tp[i] != &PyLong_Type &&
+            key.tp[i] != &PyFloat_Type && key.tp[i] != &PyBool_Type)
+            cacheable = false;
+    }
+    key.flags = (uint32_t) n | ((uint32_t) select << 8);
 
-        if (!m2.is_valid) {
-            nb::raise(
-                "Encountered an unsupported argument of type '%s' (must be a "
-                "Dr.Jit array or a type that can be converted into one)",
-                nb::inst_name(o_i).c_str());
+    nb::handle target[3];
+    bool have_targets = false;
+
+    if (NB_LIKELY(cacheable)) {
+        auto it = promote_cache.find(key);
+        if (it != promote_cache.end()) {
+            for (size_t i = 0; i < n; ++i)
+                target[i] = it->second.h[i];
+            have_targets = true;
+        }
+    }
+
+    if (NB_UNLIKELY(!have_targets)) {
+        ArrayMeta m{}, mi[3];
+        nb::handle h;
+
+        for (size_t i = 0; i < n; ++i) {
+            nb::handle o_i = o[i];
+            ArrayMeta m2 = meta_get(o_i);
+
+            if (!m2.is_valid) {
+                nb::raise(
+                    "Encountered an unsupported argument of type '%s' (must be a "
+                    "Dr.Jit array or a type that can be converted into one)",
+                    nb::inst_name(o_i).c_str());
+            }
+
+            if (i == 0)
+                m = m2;
+            else
+                m = meta_promote(m, m2);
+
+            mi[i] = m2;
         }
 
-        if (i == 0)
-            m = m2;
-        else
-            m = meta_promote(m, m2);
+        if (!meta_check(m))
+            nb::raise("Incompatible arguments.");
 
-        mi[i] = m2;
+        if ((VarType) m.type == VarType::BaseFloat)
+            m.type = (uint32_t) VarType::Float32;
+        if ((VarType) m.type == VarType::BaseInt)
+            m.type = (uint32_t) VarType::Int32;
+
+        for (size_t i = 0; i < n; ++i) {
+            // if this is a compatible Dr.Jit array
+            if (m == mi[i] && mi[i].talign)
+                h = o[i];
+        }
+
+        if (h.is_valid()) {
+            h = h.type();
+        } else {
+            if (!m.is_class) {
+                h = meta_get_type(m);
+            } else {
+                for (size_t i = 0; i < n; ++i) {
+                    ArrayMeta m2 = meta_get(o[i]);
+                    if (m2.is_class && m2.ndim == 1) {
+                        h = o[i].type();
+                        break;
+                    }
+                }
+
+                if (!h.is_valid())
+                    nb::raise("Incompatible arguments.");
+            }
+        }
+
+        for (size_t i = 0; i < n; ++i) {
+            if (select && i == 0) {
+                ArrayMeta mm = m;
+                mm.type = (uint16_t) VarType::Bool;
+                mm.is_quaternion = 0;
+                mm.is_matrix = 0;
+                mm.is_complex = 0;
+                target[i] = meta_get_type(mm);
+            } else {
+                target[i] = h;
+            }
+        }
+
+        if (cacheable) {
+            PromoteVal v;
+            for (size_t i = 0; i < n; ++i)
+                v.h[i] = target[i];
+            promote_cache.insert({ key, v });
+        }
     }
-
-    if (!meta_check(m))
-        nb::raise("Incompatible arguments.");
-
-    if ((VarType) m.type == VarType::BaseFloat)
-        m.type = (uint32_t) VarType::Float32;
-    if ((VarType) m.type == VarType::BaseInt)
-        m.type = (uint32_t) VarType::Int32;
 
     for (size_t i = 0; i < n; ++i) {
-        // if this is a compatible Dr.Jit array
-        if (m == mi[i] && mi[i].talign)
-            h = o[i];
-    }
+        nb::handle h2 = target[i];
 
-    if (h.is_valid()) {
-        h = h.type();
-    } else {
-        if (!m.is_class) {
-            h = meta_get_type(m);
-        } else {
-            for (size_t i = 0; i < n; ++i) {
-                ArrayMeta m2 = meta_get(o[i]);
-                if (m2.is_class && m2.ndim == 1) {
-                    h = o[i].type();
-                    break;
+        if (!o[i].type().is(h2)) {
+            // Fast path to broadcast a plain Python scalar (int/float/bool)
+            // into a Int/Float/Bool Dr.Jit array. flat, dynamically-sized
+            // arithmetic Dr.Jit array.
+            PyTypeObject *o_tp = (PyTypeObject *) o[i].type().ptr();
+            if (o_tp == &PyLong_Type || o_tp == &PyFloat_Type ||
+                o_tp == &PyBool_Type) {
+                const ArraySupplement &s2 = supp(h2);
+                if (s2.init_const && s2.ndim == 1 &&
+                    s2.shape[0] == DRJIT_DYNAMIC && !s2.is_complex &&
+                    !s2.is_quaternion && !s2.is_matrix && !s2.is_tensor &&
+                    !s2.is_class) {
+                    nb::object arr = nb::inst_alloc(h2);
+                    s2.init_const(1, false, o[i].ptr(), inst_ptr(arr));
+                    nb::inst_mark_ready(arr);
+                    o[i] = std::move(arr);
+                    continue;
                 }
             }
 
-            if (!h.is_valid())
-                nb::raise("Incompatible arguments.");
-        }
-    }
-
-    for (size_t i = 0; i < n; ++i) {
-        nb::handle h2 = h;
-
-        if (select && i == 0) {
-            m.type = (uint16_t) VarType::Bool;
-            m.is_quaternion = 0;
-            m.is_matrix = 0;
-            m.is_complex = 0;
-            h2 = meta_get_type(m);
-        }
-
-        if (!o[i].type().is(h2)) {
             PyObject *args[2];
             args[0] = nullptr;
             args[1] = o[i].ptr();
@@ -461,11 +556,35 @@ const char *meta_get_name(ArrayMeta meta) noexcept {
     return buffer.get();
 }
 
+// Resolving types is relatively costly. This map provides a cache to sidestep
+// the cost of constructing the string and then performing an attribute lookup.
+// The data structure is protected by the GIL.
+static tsl::robin_map<uint64_t, nb::handle, UInt64Hasher> meta_type_cache;
+
 /// Look up the nanobind type associated with the given array metadata
 nb::handle meta_get_type(ArrayMeta meta, bool fail_if_missing) {
+    static_assert(sizeof(ArrayMeta) == sizeof(uint64_t),
+                  "ArrayMeta is expected to occupy exactly 8 bytes");
+
+    // 'talign'/'tsize_rel' aren't part of type identity
+    ArrayMeta key = meta;
+    key.tsize_rel = key.talign = 0;
+
+    uint64_t cache_key;
+    memcpy(&cache_key, &key, sizeof(cache_key));
+
+    auto it = meta_type_cache.find(cache_key);
+    if (it != meta_type_cache.end())
+        return it->second;
+
     const char *name = meta_get_name(meta);
     nb::handle result = getattr(meta_get_module(meta), name, nb::handle());
-    if (!result.is_valid() && fail_if_missing)
-        nb::raise("Operation references type \"%s\", which lacks bindings", name);
+    if (!result.is_valid()) {
+        if (fail_if_missing)
+            nb::raise("Operation references type \"%s\", which lacks bindings", name);
+        return result;
+    }
+
+    meta_type_cache.insert({ cache_key, result });
     return result;
 }

--- a/src/python/meta.cpp
+++ b/src/python/meta.cpp
@@ -124,7 +124,7 @@ ArrayMeta meta_promote(ArrayMeta a, ArrayMeta b) noexcept {
 
         r.ndim = ndim_max;
 
-        for (int i = 0; i < r.ndim; ++i) {
+        for (int i = 0; i < (int) r.ndim; ++i) {
             int size_a = (i < ndim_a) ? a.shape[i] : 1,
                 size_b = (i < ndim_b) ? b.shape[i] : 1;
 
@@ -188,7 +188,7 @@ ArrayMeta meta_get(nb::handle h) noexcept {
                     break;
                 }
 
-                for (int j = 0; j < m2.ndim; ++j)
+                for (int j = 0; j < (int) m2.ndim; ++j)
                     m2.shape[j + 1] = m2.shape[j];
                 m2.shape[0] = len > 4 ? DRJIT_DYNAMIC : (uint8_t) len;
                 m2.ndim++;

--- a/src/python/reduce.cpp
+++ b/src/python/reduce.cpp
@@ -342,7 +342,7 @@ nb::object reduce(uint32_t op, nb::handle h, nb::handle axis_, nb::handle mode, 
         // and is the (only) reduced axis.
         if (keepdims) {
             bool only_trailing_reduced =
-                (axis_len == 1 && red_axis == s.ndim - 1) ||
+                (axis_len == 1 && red_axis == (int) s.ndim - 1) ||
                 (axis_len == -1 && s.ndim == 1);
             if (!only_trailing_reduced ||
                 s.shape[s.ndim - 1] != DRJIT_DYNAMIC)
@@ -436,7 +436,7 @@ nb::object reduce(uint32_t op, nb::handle h, nb::handle axis_, nb::handle mode, 
                 shape[red_axis] = 1;
             } else {
                 m.is_matrix = m.is_quaternion = m.is_complex = false;
-                for (int i = red_axis; i < m.ndim - 1; ++i) {
+                for (int i = red_axis; i < (int) m.ndim - 1; ++i) {
                     m.shape[i] = m.shape[i + 1];
                     shape[i] = shape[i + 1];
                 }

--- a/src/python/traits.cpp
+++ b/src/python/traits.cpp
@@ -292,7 +292,7 @@ void export_traits(nb::module_ &m) {
                   const ArraySupplement &s = supp(tp);
                   if (s.is_tensor)
                       return true;
-                  for (int i = 0; i < s.ndim; ++i) {
+                  for (int i = 0; i < (int) s.ndim; ++i) {
                       if (s.shape[i] == DRJIT_DYNAMIC)
                           return true;
                   }


### PR DESCRIPTION
The recent Dr.Jit-Core PR [drjit-core#194](https://github.com/mitsuba-renderer/drjit-core/pull/194) roughly doubled tracing and evaluation performance of the core library, but those speedups don't transfer directly to the Python bindings with their own dominant overheads.

This PR combines that core upgrade with two binding-level changes that target the remaining overhead:

1. **Upgrade Dr.Jit-Core** ([drjit-core#194](https://github.com/mitsuba-renderer/drjit-core/pull/194)): pulls in the low-level core optimizations.
2. **Accelerate scalar/array operator dispatch in the bindings**: caches type promotion and metadata lookups and broadcasts Python scalars directly, avoiding temporary array objects.
3. **Adopt nanobind's object pool** ([nanobind#1366](https://github.com/wjakob/nanobind/pull/1366)): speeds up short-lived array allocations during tracing.

Together they roughly **double** the speed of tracing and code generation as seen from Python.

## Compound effect

Measured with `microbenchmark.py` (from the Dr.Jit-Core repo), median of 10 runs:

```
instructions:  -49.4% trace, -48.7% codegen
trace:         9838.28 -> 4600.14 ms (53.2% faster)
trace+codegen: 771.59 -> 371.16 ms (51.9% faster)