### PR TITLE
Fix loop body aliased state dealias

### DIFF
--- a/src/python/while_loop.cpp
+++ b/src/python/while_loop.cpp
@@ -41,6 +41,8 @@ struct LoopState {
     size_t active_size;
     /// Has the alias-free working copy of 'state' been built yet?
     bool dealiased = false;
+    /// Scratch set to detect aliasing in the state on each read
+    tsl::robin_set<uint64_t, UInt64Hasher> seen;
 
     LoopState(nb::tuple &&state, nb::callable &&cond, nb::callable &&body,
               dr::vector<dr::string> &&labels, bool strict, bool check_size)
@@ -108,7 +110,8 @@ static void while_loop_read_cb(void *p, dr::vector<uint64_t> &indices) {
     // returns the same array object in several state entries.
     bool aliased = false;
     if (ls->dealiased) {
-        tsl::robin_set<uint64_t, UInt64Hasher> seen;
+        tsl::robin_set<uint64_t, UInt64Hasher> &seen = ls->seen;
+        seen.clear();
         seen.reserve(indices.size());
         for (uint64_t index : indices) {
             if (!(uint32_t) index)

--- a/src/python/while_loop.cpp
+++ b/src/python/while_loop.cpp
@@ -16,6 +16,8 @@
 #include "shape.h"
 #include "apply.h"
 #include <nanobind/stl/optional.h>
+#include <tsl/robin_set.h>
+#include <drjit-core/hash.h>
 
 /**
  * \brief This data structure is responsible for capturing and updating the
@@ -100,10 +102,25 @@ static void while_loop_read_cb(void *p, dr::vector<uint64_t> &indices) {
     LoopState *ls = (LoopState *) p;
     ls->tracker.read(ls->state, indices, ls->labels);
 
-    // On the first read, replace the live state with an alias-free working copy.
+    // On the first read, replace the live state with an alias-free working copy
     // (sharing the same indices). We will later revert this copy for state fields
-    // that have not been modified.
-    if (!ls->dealiased) {
+    // that have not been modified. This step is repeated whenever the loop body
+    // returns the same array object in several state entries.
+    bool aliased = false;
+    if (ls->dealiased) {
+        tsl::robin_set<uint64_t, UInt64Hasher> seen;
+        seen.reserve(indices.size());
+        for (uint64_t index : indices) {
+            if (!(uint32_t) index)
+                continue;
+            if (!seen.insert(index).second) {
+                aliased = true;
+                break;
+            }
+        }
+    }
+
+    if (!ls->dealiased || aliased) {
         struct DealiasShareOp : TransformCallback {
             void operator()(nb::handle h1, nb::handle h2) override {
                 const ArraySupplement &s = supp(h1.type());

--- a/tests/test_while_loop.py
+++ b/tests/test_while_loop.py
@@ -850,3 +850,104 @@ def test37_loop_multi_size_side_effects(t, mode):
 
     assert dr.sum(big)[0] == 5050
     assert small[0] == 42
+
+@pytest.mark.parametrize('mode', ['evaluated', 'symbolic'])
+@pytest.test_arrays('float32,is_jit,shape=(*)')
+@dr.syntax
+def test38_aliased_state_in_body(t, mode):
+    # Check that aliases created by the loop body are handled correctly
+    UInt32 = dr.uint32_array_t(t)
+
+    x = dr.arange(t, 4)
+    a, b, c = x + 1, x + 2, x + 3
+    i = UInt32(0)
+    while dr.hint(i < 1, mode=mode):
+        a, b, c = b, b, a
+        i += 1
+
+    assert dr.all(a == x + 2)
+    assert dr.all(b == x + 2)
+    assert dr.all(c == x + 1)
+
+@pytest.mark.parametrize('mode', ['evaluated', 'symbolic'])
+@pytest.test_arrays('float32,is_jit,shape=(*)')
+@dr.syntax
+def test39_aliased_state_partial_exit(t, mode):
+    # Aliases created by the loop body must not disturb lanes that already
+    # finished the loop
+    UInt32 = dr.uint32_array_t(t)
+
+    k = dr.arange(UInt32, 4)
+    a = dr.arange(t, 4) * 100
+    b = a + 1
+    i = UInt32(0)
+    while dr.hint(i < k, mode=mode):
+        a = b
+        i += 1
+
+    assert dr.all(b == dr.arange(t, 4) * 100 + 1)
+    assert dr.all(a == dr.select(k == 0, dr.arange(t, 4) * 100, b))
+
+@pytest.mark.parametrize('mode', ['evaluated', 'symbolic'])
+@pytest.test_arrays('float32,is_jit,shape=(*)')
+@dr.syntax
+def test40_aliased_state_shared_update(t, mode):
+    # Two state variables receiving their update from the same (also updated)
+    # state variable exercise the temporaries of the loop's backedge copy
+    UInt32 = dr.uint32_array_t(t)
+
+    x = dr.arange(t, 3)
+    a, b, c = x + 1, x + 2, x + 3
+    i = UInt32(0)
+    while dr.hint(i < 5, mode=mode):
+        a, b, c = c, c, a + b
+        i += 1
+
+    assert dr.all(a == t(12, 16, 20))
+    assert dr.all(b == t(12, 16, 20))
+    assert dr.all(c == t(12, 20, 28))
+
+@pytest.mark.parametrize('mode', ['evaluated', 'symbolic'])
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@dr.syntax
+def test41_aliased_state_in_body_ad_bwd(t, mode):
+    # Test the same thing for reverse-mode AD
+    UInt32 = dr.uint32_array_t(dr.detached_t(t))
+
+    x = t(2)
+    dr.enable_grad(x)
+
+    a, b, c = x + 1, x * x, x - 1
+    i = UInt32(0)
+    while dr.hint(i < 1, mode=mode, max_iterations=1):
+        a, b, c = b, b, a
+        i += 1
+
+    dr.backward(c)
+    assert dr.allclose(a, 4)
+    assert dr.allclose(b, 4)
+    assert dr.allclose(c, 3)
+    assert dr.allclose(dr.grad(x), 1)
+
+@pytest.mark.parametrize('mode', ['evaluated', 'symbolic'])
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@dr.syntax
+def test42_aliased_state_in_body_ad_fwd(t, mode):
+    # Test the same thing for forward-mode AD
+    UInt32 = dr.uint32_array_t(dr.detached_t(t))
+
+    x = t(2)
+    dr.enable_grad(x)
+    dr.set_grad(x, 1)
+
+    a, b, c = x + 1, x * x, x - 1
+    i = UInt32(0)
+    while dr.hint(i < 1, mode=mode):
+        a, b, c = b, b, a
+        i += 1
+
+    dr.forward_to(c)
+    assert dr.allclose(a, 4)
+    assert dr.allclose(b, 4)
+    assert dr.allclose(c, 3)
+    assert dr.allclose(dr.grad(c), 1)


### PR DESCRIPTION
This follows up on 9839054f, which de-aliases the loop state on the first read. Two cases were still broken:

**1. The loop body can re-introduce aliasing.** 
If it returns the same object in several state entries, the write-back stores a different index per entry into what is actually one object, and the last write wins. In symbolic mode this corrupts the loop when `OptimizeLoops` re-records it (or raises a "presumed to be constant" error); in evaluated mode, lanes that already exited the loop lose their value.

Reproducer:

```python
@dr.syntax
def f():
    x = dr.arange(Int, 3)
    a, b, c = x + 1, x + 2, x + 3
    i = Int(0)
    while i < 1:
        a, b, c = b, b, a
        i += 1
    return c

print(f())   # should be [1, 2, 3], prints [2, 3, 4]
```

The fix simply repeats the de-aliasing step when the freshly read state contains the same variable twice (O(n) check, the copy is only made when aliasing is actually present).

**2. Two state variables sharing one update value produce invalid CUDA/Metal kernels.** 
The loop back-edge names its temporaries after the *destination* register, so e.g. `a, b, c = c, c, a + b` declared one temporary but referenced two; ptxas then fails with `Unknown symbol '%rXX_tmp'`. 
See https://github.com/mitsuba-renderer/drjit-core/pull/198.