### PR TITLE
Fix derivative tracking for static packet scatter(-reduce)

### DIFF
--- a/include/drjit/autodiff.h
+++ b/include/drjit/autodiff.h
@@ -567,7 +567,7 @@ struct DRJIT_TRIVIAL_ABI DiffArray
             for (uint32_t i = 0; i < N; ++i)
                 indices[i] = source[i].index_combined();
 
-            dst = steal(ad_var_scatter_packet(N, dst.index(), indices,
+            dst = steal(ad_var_scatter_packet(N, dst.index_combined(), indices,
                                               index.index(), mask.index(),
                                               ReduceOp::Identity, mode));
         } else {
@@ -608,7 +608,7 @@ struct DRJIT_TRIVIAL_ABI DiffArray
             for (uint32_t i = 0; i < N; ++i)
                 indices[i] = source[i].index_combined();
 
-            dst = steal(ad_var_scatter_packet(N, dst.index(), indices,
+            dst = steal(ad_var_scatter_packet(N, dst.index_combined(), indices,
                                               index.index(), mask.index(),
                                               op, mode));
         } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ add_drjit_test(if_stmt_ext if_stmt_ext.cpp)
 add_drjit_test(custom_type_ext custom_type_ext.cpp)
 add_drjit_test(py_cpp_consistency_ext py_cpp_consistency_ext.cpp)
 add_drjit_test(local_ext local_ext.cpp)
+add_drjit_test(memop_ext memop_ext.cpp)
 
 file(GLOB TEST_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.py")
 

--- a/tests/memop_ext.cpp
+++ b/tests/memop_ext.cpp
@@ -1,0 +1,62 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/pair.h>
+#include <drjit/python.h>
+#include <drjit/autodiff.h>
+#include <drjit/util.h>
+
+namespace nb = nanobind;
+namespace dr = drjit;
+
+template <JitBackend Backend> void bind(nb::module_ m) {
+    using Float = dr::DiffArray<Backend, float>;
+    using UInt32 = dr::uint32_array_t<Float>;
+    using Array2f = dr::Array<Float, 2>;
+    using Pair = std::pair<Float, Float>;
+
+    m.def("gather", [](Float source, UInt32 index) {
+        return dr::gather<Float>(source, index);
+    });
+
+    m.def("scatter", [](Float target, Float value, UInt32 index) {
+        dr::scatter_reduce(ReduceOp::Add, target, value, index);
+        return target;
+    });
+
+    m.def("packet_gather", [](Float source, UInt32 index) -> Pair {
+        Array2f r = dr::gather<Array2f>(source, index);
+        return { r.x(), r.y() };
+    });
+
+    m.def("packet_scatter", [](Float target, Float v0, Float v1, UInt32 index) {
+        dr::scatter_reduce(ReduceOp::Add, target, Array2f(v0, v1), index);
+        return target;
+    });
+
+    m.def("packet_gather_dynamic", [](Float source, UInt32 index) -> Pair {
+        Float out[2];
+        dr::gather_packet_dynamic(2, source, index, out, true);
+        return { out[0], out[1] };
+    });
+
+    m.def("packet_scatter_dynamic", [](Float target, Float v0, Float v1, UInt32 index) {
+        Float values[2] = { v0, v1 };
+        dr::scatter_reduce_packet_dynamic(ReduceOp::Add, 2, target, values, index, true);
+        return target;
+    });
+}
+
+NB_MODULE(memop_ext, m) {
+    nb::module_::import_("drjit");
+
+#if defined(DRJIT_ENABLE_LLVM)
+    bind<JitBackend::LLVM>(m.def_submodule("llvm"));
+#endif
+
+#if defined(DRJIT_ENABLE_CUDA)
+    bind<JitBackend::CUDA>(m.def_submodule("cuda"));
+#endif
+
+#if defined(DRJIT_ENABLE_METAL)
+    bind<JitBackend::Metal>(m.def_submodule("metal"));
+#endif
+}

--- a/tests/test_memop_ext.py
+++ b/tests/test_memop_ext.py
@@ -1,0 +1,74 @@
+import drjit as dr
+import pytest
+import sys
+
+
+def get_pkg(t):
+    with dr.detail.scoped_rtld_deepbind():
+        m = pytest.importorskip("memop_ext")
+    backend = dr.backend_v(t)
+    if backend == dr.JitBackend.LLVM:
+        return m.llvm
+    elif backend == dr.JitBackend.CUDA:
+        return m.cuda
+    elif backend == dr.JitBackend.Metal:
+        return m.metal
+
+
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@pytest.mark.parametrize('fn,packet', [('gather', False),
+                                       ('packet_gather', True),
+                                       ('packet_gather_dynamic', True)])
+def test01_gather(t, fn, packet):
+    pkg = get_pkg(t)
+    UInt32 = sys.modules[t.__module__].UInt32
+    index = UInt32(0, 2)
+    source, source_r = dr.arange(t, 8) + 0.5, dr.arange(t, 8) + 0.5
+    dr.enable_grad(source, source_r)
+
+    if packet:
+        a, b = getattr(pkg, fn)(source, index)
+        r, r_ref = a + b, dr.gather(t, source_r, index * 2) + \
+                          dr.gather(t, source_r, index * 2 + 1)
+    else:
+        r, r_ref = pkg.gather(source, index), dr.gather(t, source_r, index)
+
+    dr.backward(dr.sum(r))
+    dr.backward(dr.sum(r_ref))
+    assert dr.allclose(r, r_ref)
+    assert dr.allclose(dr.grad(source), dr.grad(source_r))
+
+
+@pytest.skip_on(RuntimeError, "backend does not support the requested type of atomic reduction")
+@pytest.test_arrays('float32,is_diff,shape=(*)')
+@pytest.mark.parametrize('fn,packet', [('scatter', False),
+                                       ('packet_scatter', True),
+                                       ('packet_scatter_dynamic', True)])
+def test02_scatter(t, fn, packet):
+    pkg = get_pkg(t)
+    UInt32 = sys.modules[t.__module__].UInt32
+    target, target_r = dr.full(t, 1, 6), dr.full(t, 1, 6)
+    acc = dr.zeros(t, 6)
+
+    if packet:
+        index = UInt32(0, 1)
+        vals = [t(10, 20), t(30, 40)]
+        vals_r = [t(10, 20), t(30, 40)]
+        dr.enable_grad(target, target_r, *vals, *vals_r)
+        r = getattr(pkg, fn)(target, vals[0], vals[1], index)
+        for j, v_r in enumerate(vals_r):
+            dr.scatter_reduce(dr.ReduceOp.Add, acc, v_r, index * 2 + j)
+    else:
+        index = UInt32(0, 5)
+        vals, vals_r = [t(10, 20)], [t(10, 20)]
+        dr.enable_grad(target, target_r, *vals, *vals_r)
+        r = pkg.scatter(target, vals[0], index)
+        dr.scatter_reduce(dr.ReduceOp.Add, acc, vals_r[0], index)
+
+    r_ref = target_r + acc
+    dr.backward(dr.sum(r))
+    dr.backward(dr.sum(r_ref))
+    assert dr.allclose(r, r_ref)
+    assert dr.allclose(dr.grad(target), dr.grad(target_r))
+    for v, v_r in zip(vals, vals_r):
+        assert dr.allclose(dr.grad(v), dr.grad(v_r))


### PR DESCRIPTION
``DiffArray::scatter_[reduce_]packet_`` passed ``dst.index()`` (the JIT-only lower 32 bits) as the scatter target. As a result, gradients were not propagated to the prior contents of the target buffer when it was attached to the AD graph. This commit fixes that. It also adds C++ tests (``tests/memop_ext.cpp``, ``test_memop_ext.py``) that were otherwise not covered by the test suite.