### PR TITLE
Fix minor metal warning

### DIFF
--- a/src/python/texture.h
+++ b/src/python/texture.h
@@ -44,7 +44,7 @@ static nb::object tex_eval_fetch(const Tex &texture,
                                  const dr::Array<T, Dimension> &pos,
                                  const dr::mask_t<T> &active) {
     constexpr size_t ResultSize = 1 << Dimension;
-    auto to_tuple = [ResultSize](auto &&corners) {
+    auto to_tuple = [](auto &&corners) {
         nb::object out = nb::steal(PyTuple_New((Py_ssize_t) ResultSize));
         for (size_t i = 0; i < ResultSize; ++i)
             NB_TUPLE_SET_ITEM(out.ptr(), (Py_ssize_t) i,


### PR DESCRIPTION
Remove unused `ResultSize` capture from the `to_tuple` lambda in `tex_eval_fetch`. Since `ResultSize` is `constexpr`, it as constant initialization and does not need to be captured by the lambda, it is already usable inside the body via name lookup.

This silences a `-Wunused-lambda-capture` warning emitted by Clang for every instantiation of `bind_texture<Type, Dimension>` (3 dtypes × 3 dimensions × 3 result types = 27 instances per translation unit), considerably reducing build noise in `scalar.cpp` and other Python binding TUs.