### PR TITLE
Texture class improvements: 8-bit textures, scalar evaluation path

### DIFF
--- a/docs/textures.rst
+++ b/docs/textures.rst
@@ -156,6 +156,25 @@ the primal lookup operation is hardware-accelerated, a subsequent
 non-accelerated lookup is additionally performed *solely* to record each
 individual operation into the AD graph.
 
+8-bit textures
+^^^^^^^^^^^^^^
+
+The interface of ``Texture?f8u`` variants (e.g. :py:class:`Texture3f8u
+<drjit.auto.ad.Texture3f8u>`) slightly differs from their floating point
+counterparts. They store texture data compactly using unsigned 8-bit integers,
+but their ``eval_*`` members produce floating point output by transparently
+remapping ``0..255`` onto the interval ``[0, 1]``.
+
+When the texture object was created with ``srgb=True``, i.e.,
+
+.. code-block:: python
+
+   tex = Texture2f8u(tensor_u8, srgb=True)
+
+evaluation will apply the nonlinear sRGB transfer function to turn
+gamma-encoded 8-bit values back into a linear scale. The CUDA and Metal
+backends perform both types of conversions in hardware.
+
 Writing to textures
 -------------------
 
@@ -178,11 +197,10 @@ The access mode follows the *operation*, so a ``writable`` texture may be both
 written and sampled (a texture rendered in one kernel can be looked up in
 another). Its contents can be read back into a tensor via :py:func:`.tensor()
 <drjit.auto.Texture2f.tensor>` / :py:func:`.value()
-<drjit.auto.Texture2f.value>` as usual. On Metal the underlying texture is
-created with shader-write usage; on CUDA it is backed by a surface object.
+<drjit.auto.Texture2f.value>` as usual. Writing 8-bit textures clips and
+quantizes ``[0, 1]`` float inputs and sRGB-encodes them if needed.
 
-This feature requires the CUDA or Metal backend (it is unavailable for
-``llvm``/``scalar`` textures, and for double-precision textures).
+This feature requires a JIT backend; it is unavailable for ``scalar`` textures.
 
 Wrapping native textures
 ------------------------

--- a/docs/type_ref.rst
+++ b/docs/type_ref.rst
@@ -626,6 +626,32 @@ Textures
    .. automethod:: eval_cubic_hessian
    .. automethod:: eval_cubic_helper
 
+.. autoclass:: drjit.scalar.Texture3f8u
+
+   .. automethod:: __init__
+   .. automethod:: set_value
+   .. automethod:: set_tensor
+   .. automethod:: update_inplace
+   .. automethod:: value
+   .. automethod:: tensor
+   .. automethod:: filter_mode
+   .. automethod:: wrap_mode
+   .. automethod:: use_accel
+   .. automethod:: migrated
+   .. automethod:: writable
+   .. automethod:: srgb
+   .. automethod:: from_native_handle
+   .. automethod:: map
+   .. automethod:: unmap
+   .. automethod:: native_handle
+   .. autoproperty:: shape
+   .. automethod:: eval
+   .. automethod:: eval_fetch
+   .. automethod:: eval_cubic
+   .. automethod:: eval_cubic_grad
+   .. automethod:: eval_cubic_hessian
+   .. automethod:: eval_cubic_helper
+
 Random number generators
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/include/drjit/extra.h
+++ b/include/drjit/extra.h
@@ -153,14 +153,11 @@ extern DRJIT_EXTRA_EXPORT uint64_t ad_var_reduce_dot(uint64_t i0, uint64_t i1);
 
 /// Transpose the last two dimensions of a row-major tensor. The input is
 /// interpreted as a (``batch``, ``M``, ``N``) view over ``source``'s flat
-/// storage, and the output has shape (``batch``, ``N``, ``M``). The shape
-/// relabel lives on the caller side — this function returns a flat JIT
-/// variable of size ``batch * M * N``. Built on top of ``ad_var_gather``:
-/// both forward and reverse-mode AD are handled by the underlying gather,
-/// which recognizes the 1-to-1 permutation via ``ReduceMode::Permute``.
+/// storage, and the output has shape (``batch``, ``N``, ``M``).
 extern DRJIT_EXTRA_EXPORT uint64_t ad_var_transpose(uint64_t source,
                                                     uint32_t batch,
-                                                    uint32_t M, uint32_t N);
+                                                    uint32_t M,
+                                                    uint32_t N);
 
 /// Differentiable matrix multiplication. See \ref jit_var_batched_gemm for
 /// the shape, transpose, and batching convention — this entry point follows
@@ -236,6 +233,7 @@ extern DRJIT_EXTRA_EXPORT uint64_t ad_var_cast(uint64_t, VarType);
  * \param dimension         Texture dimensionality (1, 2, or 3).
  * \param channels_stored   Storage channel count (power of two >= channels_out).
  * \param channels_out      Number of (unpadded) output channels.
+ * \param srgb              Decode sRGB to linear (UInt8 textures only).
  * \param value             Combined index of the padded texture storage tensor.
  * \param res               One opaque UInt32 JIT index per dimension (w, h, d).
  * \param idiv              Per-dimension magic-division constants of
@@ -247,7 +245,7 @@ extern DRJIT_EXTRA_EXPORT uint64_t ad_var_cast(uint64_t, VarType);
  */
 extern DRJIT_EXTRA_EXPORT void
 ad_tex_eval(VarType query_type, uint32_t dimension, uint32_t channels_stored,
-            uint32_t channels_out, int filter_mode, int wrap_mode,
+            uint32_t channels_out, int filter_mode, int wrap_mode, int srgb,
             void *handle, int use_accel, uint64_t value, const uint32_t *res,
             const uint32_t *idiv, const uint64_t *pos, uint32_t active,
             uint64_t *out);
@@ -260,7 +258,7 @@ ad_tex_eval(VarType query_type, uint32_t dimension, uint32_t channels_stored,
  */
 extern DRJIT_EXTRA_EXPORT void
 ad_tex_fetch(VarType query_type, uint32_t dimension, uint32_t channels_stored,
-             uint32_t channels_out, int wrap_mode, void *handle,
+             uint32_t channels_out, int wrap_mode, int srgb, void *handle,
              int use_accel, uint64_t value, const uint32_t *res,
              const uint32_t *idiv, const uint64_t *pos, uint32_t active,
              uint64_t *out);
@@ -282,7 +280,7 @@ ad_tex_wrap(uint32_t dimension, int wrap_mode, const uint32_t *res,
 /// Evaluate a clamped cubic B-spline interpolant (see \ref ad_tex_eval).
 extern DRJIT_EXTRA_EXPORT void
 ad_tex_cubic(VarType query_type, uint32_t dimension, uint32_t channels_stored,
-             uint32_t channels_out, int wrap_mode, void *handle,
+             uint32_t channels_out, int wrap_mode, int srgb, void *handle,
              int use_accel, uint64_t value, const uint32_t *res,
              const uint32_t *idiv, const uint64_t *pos, uint32_t active,
              uint64_t *out);
@@ -298,15 +296,17 @@ ad_tex_cubic(VarType query_type, uint32_t dimension, uint32_t channels_stored,
  */
 extern DRJIT_EXTRA_EXPORT void
 ad_tex_cubic_deriv(VarType query_type, uint32_t dimension, uint32_t channels_stored,
-                   uint32_t channels_out, int wrap_mode, uint64_t value,
+                   uint32_t channels_out, int wrap_mode, int srgb, uint64_t value,
                    const uint32_t *res, const uint32_t *idiv,
                    const uint64_t *pos, uint32_t active, uint64_t *out_value,
                    uint64_t *out_grad, uint64_t *out_hess);
 
-/// Store ``channels_out`` values into a writable hardware texture (\ref Texture::write).
+/// Store ``channels_out`` values into a writable texture. For textures with
+/// 8-bit storage, values are clamped, potentially sRGB-encoded, and rounded.
 extern DRJIT_EXTRA_EXPORT void
-ad_tex_write(uint32_t channels_stored, uint32_t channels_out, void *handle,
-             const uint32_t *pos, const uint64_t *value, uint32_t active);
+ad_tex_write(uint32_t channels_stored, uint32_t channels_out,
+             VarType storage_type, int srgb, void *handle, const uint32_t *pos,
+             const uint64_t *value, uint32_t active);
 
 /**
  * \brief Re-pack channel-interleaved texture data to a different channel width

--- a/include/drjit/texture.h
+++ b/include/drjit/texture.h
@@ -23,6 +23,7 @@
 #include <drjit/util.h>
 #include <drjit/traversable_base.h>
 #include <array>
+#include <cassert>
 
 #pragma once
 
@@ -89,6 +90,14 @@ public:
      * defines the wrapping method. The default behavior is \ref
      * WrapMode::Clamp, which indefinitely extends the colors on the boundary
      * along each dimension.
+     *
+     * On the CUDA and Metal backends, hardware texture units resolve the
+     * sub-texel position using reduced-precision fixed-point weights (8
+     * fractional bits on CUDA, i.e. 256 steps between texels). This does not
+     * degrade the stored values or the interpolated quantity, only how finely
+     * the fractional position within a texel is resolved. Set \c use_accel to
+     * \c false to disable the texture units and avoid this approximation at some
+     * cost in performance.
      *
      * For 8-bit textures, setting \c srgb additionally requests that samples
      * be decoded from sRGB to linear. Passing it for a floating-point texture
@@ -536,29 +545,8 @@ public:
         return out;
     }
 
-    /// Scalar fallback for \ref eval_nonaccel(); the JIT path uses the
-    /// type-erased kernel in ``libdrjit-extra``
-    template <typename Output, typename Value = value_t<Output>>
-    void eval_nonaccel_scalar(const position_for<Output> &pos, Output &out,
-                              mask_for<Output> active = true) const {
-        Value *res_mem     = (Value *) alloca(sizeof(Value) * m_channels);
-        Value *scratch_mem = (Value *) alloca(sizeof(Value) * m_channels);
-        detail::tex_scratch<Value> res(res_mem, m_channels),
-                                   scratch(scratch_mem, m_channels);
-        detail::tex_eval(scalar_ops<Value>(active), pos.data(), res.data(),
-                         scratch.data());
-        for (size_t ch = 0; ch < m_channels; ++ch)
-            out.set_entry(ch, res[ch]);
-    }
-
     /**
      * \brief Evaluate the linear interpolant represented by this texture
-     *
-     * On the JIT backends the evaluation is performed by the type-erased
-     * ``ad_tex_eval`` kernel in ``libdrjit-extra``, which uses the hardware
-     * texture units when available and re-attaches the differentiable
-     * arithmetic for gradient tracking. The scalar backend uses \ref
-     * eval_nonaccel().
      *
      * When using the non-hardware-accelerated evaluation, the numerical
      * precision of the interpolation is dictated by the floating point
@@ -642,15 +630,28 @@ public:
                              mask_for<Output> active = true) const {
         using Value = value_t<Output>;
         constexpr size_t ncorner = 1 << Dimension;
-        Value *buf_mem = (Value *) alloca(sizeof(Value) * ncorner * m_channels);
-        detail::tex_scratch<Value> buf(buf_mem, ncorner * m_channels);
-        Value *ptrs[ncorner];
-        for (size_t c = 0; c < ncorner; ++c)
-            ptrs[c] = buf.data() + c * m_channels;
-        detail::tex_fetch(scalar_ops<Value>(active), pos.data(), ptrs);
-        for (size_t c = 0; c < ncorner; ++c)
-            for (size_t ch = 0; ch < m_channels; ++ch)
-                out.entry(c).set_entry(ch, ptrs[c][ch]);
+        if constexpr (!is_jit_v<Storage_> && !is_dynamic_v<Output>) {
+            constexpr uint32_t C = (uint32_t) size_v<Output>;
+            assert(m_channels == C);
+            Value buf[ncorner * C];
+            Value *ptrs[ncorner];
+            for (uint32_t c = 0; c < ncorner; ++c)
+                ptrs[c] = buf + c * C;
+            detail::tex_fetch(scalar_ops<Value, C>(active), pos.data(), ptrs);
+            for (uint32_t c = 0; c < ncorner; ++c)
+                for (uint32_t ch = 0; ch < C; ++ch)
+                    out.entry(c).set_entry(ch, ptrs[c][ch]);
+        } else {
+            Value *buf_mem = (Value *) alloca(sizeof(Value) * ncorner * m_channels);
+            detail::tex_scratch<Value> buf(buf_mem, ncorner * m_channels);
+            Value *ptrs[ncorner];
+            for (size_t c = 0; c < ncorner; ++c)
+                ptrs[c] = buf.data() + c * m_channels;
+            detail::tex_fetch(scalar_ops<Value>(active), pos.data(), ptrs);
+            for (size_t c = 0; c < ncorner; ++c)
+                for (size_t ch = 0; ch < m_channels; ++ch)
+                    out.entry(c).set_entry(ch, ptrs[c][ch]);
+        }
     }
 
     /**
@@ -705,17 +706,30 @@ public:
         using Value = value_t<Output>;
         Output out = alloc_output<Output>();
 
-        // Per-channel scratch on the stack (this helper also runs on JIT arrays
-        // to build an AD graph, hence ``tex_scratch``).
-        Value *res_mem     = (Value *) alloca(sizeof(Value) * m_channels);
-        Value *scratch_mem = (Value *) alloca(sizeof(Value) * m_channels);
-        detail::tex_scratch<Value> res(res_mem, m_channels),
-                                   scratch(scratch_mem, m_channels);
+        // This helper also runs on JIT arrays (to build an AD graph), whose
+        // storage is channel-padded; only unpadded scalar storage with a
+        // statically-sized output can use the compile-time channel count. The
+        // ``else`` keeps the ``alloca`` out of the static path entirely (so it
+        // stays inlinable), rather than relying on dead-code elimination.
+        if constexpr (!is_jit_v<Storage_> && !is_dynamic_v<Output>) {
+            constexpr uint32_t C = (uint32_t) size_v<Output>;
+            assert(m_channels == C);
+            Value res[C], scratch[C];
+            detail::tex_eval_cubic(scalar_ops<Value, C>(active), pos.data(),
+                                   res, scratch);
+            for (uint32_t ch = 0; ch < C; ++ch)
+                out.set_entry(ch, res[ch]);
+        } else {
+            Value *res_mem     = (Value *) alloca(sizeof(Value) * m_channels);
+            Value *scratch_mem = (Value *) alloca(sizeof(Value) * m_channels);
+            detail::tex_scratch<Value> res(res_mem, m_channels),
+                                       scratch(scratch_mem, m_channels);
 
-        detail::tex_eval_cubic(scalar_ops<Value>(active), pos.data(),
-                               res.data(), scratch.data());
-        for (size_t ch = 0; ch < m_channels; ++ch)
-            out.set_entry(ch, res[ch]);
+            detail::tex_eval_cubic(scalar_ops<Value>(active), pos.data(),
+                                   res.data(), scratch.data());
+            for (size_t ch = 0; ch < m_channels; ++ch)
+                out.set_entry(ch, res[ch]);
+        }
         return out;
     }
 
@@ -867,27 +881,41 @@ public:
         }
     }
 
-    /// Gather the channels at \c idx and cast them to the query precision
+    /// Cast a raw stored texel to the query precision. For 8-bit storage this
+    /// normalizes 0..255 to [0, 1] and optionally decodes sRGB (matching the
+    /// hardware read; the sRGB formats leave each RGBA group's 4th channel
+    /// linear). A plain cast for floating-point storage.
     template <typename Value>
+    Value convert_texel(const Storage_ &s, uint32_t ch) const {
+        Value v = Value(s);
+        if constexpr (IsUInt8) {
+            v *= Value(1.f / 255.f);
+            if (m_srgb && (ch % 4) != 3)
+                v = srgb_to_linear(v);
+        }
+        return v;
+    }
+
+    /// Gather the channels at \c idx and cast them to the query precision.
+    /// ``CChannels`` is the channel count when statically known (fixed scratch,
+    /// unrolled loop); 0 selects the runtime ``alloca`` path.
+    template <uint32_t CChannels = 0, typename Value>
     void gather_texel(const uint32_array_t<Value> &idx,
                       const mask_t<Value> &active, Value *out) const {
-        // Per-channel packet scratch on the stack
-        Storage_ *packet_mem = (Storage_ *) alloca(sizeof(Storage_) * m_channels_storage);
-        detail::tex_scratch<Storage_> packet(packet_mem, m_channels_storage);
-
-        gather_packet_dynamic(m_channels_storage, m_value.array(), idx,
-                              packet.data(), active);
-        for (uint32_t ch = 0; ch < m_channels; ++ch) {
-            Value v = Value(packet[ch]);
-            // 8-bit storage is gathered as 0..255; normalize (and decode sRGB)
-            // to match the hardware texture units' normalized read. The sRGB
-            // formats leave each RGBA sub-texture's 4th (alpha) channel linear.
-            if constexpr (IsUInt8) {
-                v *= Value(1.f / 255.f);
-                if (m_srgb && (ch % 4) != 3)
-                    v = srgb_to_linear(v);
-            }
-            out[ch] = v;
+        if constexpr (CChannels != 0) {
+            // Scalar storage is unpadded, so m_channels_storage == CChannels.
+            Storage_ packet[CChannels];
+            gather_packet_dynamic(CChannels, m_value.array(), idx, packet, active);
+            for (uint32_t ch = 0; ch < CChannels; ++ch)
+                out[ch] = convert_texel<Value>(packet[ch], ch);
+        } else {
+            // Per-channel packet scratch on the stack
+            Storage_ *packet_mem = (Storage_ *) alloca(sizeof(Storage_) * m_channels_storage);
+            detail::tex_scratch<Storage_> packet(packet_mem, m_channels_storage);
+            gather_packet_dynamic(m_channels_storage, m_value.array(), idx,
+                                  packet.data(), active);
+            for (uint32_t ch = 0; ch < m_channels; ++ch)
+                out[ch] = convert_texel<Value>(packet[ch], ch);
         }
     }
 
@@ -1071,16 +1099,21 @@ private:
             output[Dimension] = m_value.shape(Dimension);
     }
 
-    /// Operations object for generating scalar texture evaluation code
-    template <typename Value> struct ScalarOps {
+    /// Operations object for generating scalar texture evaluation code.
+    /// ``CChannels`` is the channel count when statically known (so the loops
+    /// unroll), or 0 for a runtime count (see \ref detail::ChannelCount).
+    template <typename Value, uint32_t CChannels = 0>
+    struct ScalarOps : detail::ChannelCount<CChannels> {
         using Float = Value;
         using Int   = int32_array_t<Value>;
         using UInt  = uint32_array_t<Value>;
         using Mask  = mask_t<Value>;
 
+        // The texture dimension is always a compile-time constant
+        static constexpr uint32_t dim = (uint32_t) Dimension;
+
         const Texture *tex;
         Mask active;
-        uint32_t dim, channels_out;
         FilterMode filter_mode;
         WrapMode wrap_mode;
 
@@ -1090,17 +1123,21 @@ private:
         Float to_float(const Int &i) const { return Value(i); }
         Int idiv(const Int &a, uint32_t k) const { return tex->m_inv_resolution[k](a); }
         void gather(const UInt &idx, Float *out) const {
-            tex->gather_texel(idx, active, out);
+            tex->template gather_texel<CChannels>(idx, active, out);
         }
     };
 
     /// Build a \ref ScalarOps bound to this texture and the query mask
-    template <typename Value>
-    ScalarOps<Value> scalar_ops(mask_t<Value> active) const {
+    template <typename Value, uint32_t CChannels = 0>
+    ScalarOps<Value, CChannels> scalar_ops(mask_t<Value> active) const {
         if constexpr (!is_array_v<mask_t<Value>>)
             active = true;
-        return ScalarOps<Value>{ this, active, (uint32_t) Dimension,
-            (uint32_t) m_channels, m_filter_mode, m_wrap_mode };
+        if constexpr (CChannels != 0)
+            return ScalarOps<Value, CChannels>{ {}, this, active, m_filter_mode,
+                                                m_wrap_mode };
+        else
+            return ScalarOps<Value, 0>{ { (uint32_t) m_channels }, this, active,
+                                        m_filter_mode, m_wrap_mode };
     }
 
     // -- Type-erased marshalling helpers backing the JIT ``ad_tex_*`` calls --
@@ -1166,7 +1203,7 @@ private:
             return Value::steal((uint32_t) index);
     }
 
-    /// Evaluate via the type-erased ``ad_tex_eval`` kernel (JIT backends only)
+    /// Evaluate the texture interpolant symbolically
     template <typename Output, typename Value = value_t<Output>>
     void eval_jit(const position_for<Output> &pos, Output &out,
                   mask_for<Output> active, bool use_accel) const {
@@ -1180,6 +1217,30 @@ private:
         for (size_t ch = 0; ch < m_channels; ++ch)
             out.set_entry(ch, steal_value<Value>(out_idx[ch]));
     }
+
+    /// Scalar fallback for \ref eval_nonaccel().
+    template <typename Output, typename Value = value_t<Output>>
+    void eval_nonaccel_scalar(const position_for<Output> &pos, Output &out,
+                              mask_for<Output> active = true) const {
+        if constexpr (!is_jit_v<Storage_> && !is_dynamic_v<Output>) {
+            constexpr uint32_t C = (uint32_t) size_v<Output>;
+            assert(m_channels == C);
+            Value res[C], scratch[C];
+            detail::tex_eval(scalar_ops<Value, C>(active), pos.data(), res, scratch);
+            for (uint32_t ch = 0; ch < C; ++ch)
+                out.set_entry(ch, res[ch]);
+        } else {
+            Value *res_mem     = (Value *) alloca(sizeof(Value) * m_channels);
+            Value *scratch_mem = (Value *) alloca(sizeof(Value) * m_channels);
+            detail::tex_scratch<Value> res(res_mem, m_channels),
+                                       scratch(scratch_mem, m_channels);
+            detail::tex_eval(scalar_ops<Value>(active), pos.data(), res.data(),
+                             scratch.data());
+            for (size_t ch = 0; ch < m_channels; ++ch)
+                out.set_entry(ch, res[ch]);
+        }
+    }
+
 
     /// Shared marshaller for \ref eval_cubic_grad() / \ref eval_cubic_hessian():
     /// fills value + gradient (and hessian, when \c out_hessian is non-null).
@@ -1240,30 +1301,43 @@ private:
     void *m_handle = nullptr;
     size_t m_size = 0;                       ///< Total size of array
     size_t m_channels = 0;                   ///< Number of channels
+
     /// Rounded-up number of channels (depends on the backend)
     size_t m_channels_storage = 0;
-    size_t m_shape[Dimension + 1] = {};      ///< Unpadded shape of texture
-    mutable TensorXf m_value;                ///< Tensor padded for packet size
+
+    /// Unpadded shape of texture
+    size_t m_shape[Dimension + 1] = {};
+
+    /// Tensor padded for packet size
+    mutable TensorXf m_value;
+
     /// Lazily computed if texture data is updated after initialization
     mutable TensorXf m_unpadded_value;
 
     // Stored in this order: width, height, depth
     Array<UInt32, Dimension> m_resolution_opaque;
 
-    // Reciprocal resolution for the Repeat/Mirror wrap math. On the JIT backends
-    // the magic constants are opaque variables consumed by the type-erased
-    // kernel (see ad_tex_eval); populated only when the wrap mode divides.
+    // Reciprocal resolution for the Repeat/Mirror wrap math.
     Divisor m_inv_resolution[Dimension] { };
 
+    /// Texture interpolation mode
     FilterMode m_filter_mode;
+
+    /// Texture wrapping mode
     WrapMode m_wrap_mode;
+
+    /// Use the hardware texture units?
     bool m_use_accel = false;
+
     /// Texture was created so kernels may store into it via write()
     bool m_writable = false;
+
     /// 8-bit textures: decode sRGB -> linear on sampling
     bool m_srgb = false;
+
     /// Hardware-texture flag: is the data held exclusively on the device?
     mutable bool m_migrated = false;
+
     /// Does the public-facing unpadded tensor need to be updated?
     mutable bool m_tensor_dirty = false;
 

--- a/include/drjit/texture.h
+++ b/include/drjit/texture.h
@@ -13,6 +13,7 @@
 #include <drjit/array.h>
 #include <drjit-core/half.h>
 #include <drjit-core/texture.h>
+#include <drjit/color.h>
 #include <drjit/dynamic.h>
 #include <drjit/extra.h>
 #include <drjit/texture_impl.h>
@@ -31,13 +32,15 @@ template <typename Storage_, size_t Dimension> class Texture : TraversableBase {
 public:
     static constexpr bool IsCUDA = is_cuda_v<Storage_>;
     static constexpr bool IsMetal = is_metal_v<Storage_>;
-    static constexpr bool IsDiff = is_diff_v<Storage_>;
     static constexpr bool IsDynamic = is_dynamic_v<Storage_>;
     static constexpr bool IsHalf = std::is_same_v<scalar_t<Storage_>, drjit::half>;
     static constexpr bool IsSingle = std::is_same_v<scalar_t<Storage_>, float>;
+    static constexpr bool IsUInt8 = std::is_same_v<scalar_t<Storage_>, uint8_t>;
+    static constexpr bool IsDiff = is_diff_v<Storage_> && !IsUInt8;
 
-    // Only half/single-precision floating-point hardware textures are supported
-    static constexpr bool HasGPUTexture = (IsHalf || IsSingle) && (IsCUDA || IsMetal);
+    // Half/single-precision float and normalized 8-bit hardware textures are supported
+    static constexpr bool HasGPUTexture =
+        (IsHalf || IsSingle || IsUInt8) && (IsCUDA || IsMetal);
 
     using Int32 = int32_array_t<Storage_>;
     using UInt32 = uint32_array_t<Storage_>;
@@ -86,12 +89,18 @@ public:
      * defines the wrapping method. The default behavior is \ref
      * WrapMode::Clamp, which indefinitely extends the colors on the boundary
      * along each dimension.
+     *
+     * For 8-bit textures, setting \c srgb additionally requests that samples
+     * be decoded from sRGB to linear. Passing it for a floating-point texture
+     * raises an error. Channels are grouped into hardware RGBA quads, so within
+     * each group of four the first three are decoded and the fourth (alpha) is
+     * left linear (e.g. channel 3 is linear for a 6-channel texture).
      */
     Texture(const size_t shape[Dimension], size_t channels,
             bool use_accel = true,
             FilterMode filter_mode = FilterMode::Linear,
             WrapMode wrap_mode = WrapMode::Clamp,
-            bool writable = false) {
+            bool writable = false, bool srgb = false) : m_srgb(srgb) {
         init(shape, channels, use_accel, filter_mode, wrap_mode,
              /* init_tensor = */ true, writable);
     }
@@ -116,7 +125,8 @@ public:
     template <typename TensorT>
     Texture(TensorT &&tensor, bool use_accel = true, bool migrate = true,
             FilterMode filter_mode = FilterMode::Linear,
-            WrapMode wrap_mode = WrapMode::Clamp) {
+            WrapMode wrap_mode = WrapMode::Clamp, bool srgb = false)
+        : m_srgb(srgb) {
         if (tensor.ndim() != Dimension + 1)
             jit_raise("Texture::Texture(): tensor dimension must equal "
                         "texture dimension plus one.");
@@ -145,8 +155,9 @@ public:
      */
     static Texture from_native_handle(uintptr_t handle, bool writable = false,
                                       FilterMode filter_mode = FilterMode::Linear,
-                                      WrapMode wrap_mode = WrapMode::Clamp) {
-        return Texture(handle, writable, filter_mode, wrap_mode);
+                                      WrapMode wrap_mode = WrapMode::Clamp,
+                                      bool srgb = false) {
+        return Texture(handle, writable, filter_mode, wrap_mode, srgb);
     }
 
     Texture(Texture &&other) noexcept { move_from(std::move(other)); }
@@ -171,12 +182,15 @@ public:
 private:
     /// Private constructor for \ref from_native_handle()
     Texture(uintptr_t handle, bool writable, FilterMode filter_mode,
-            WrapMode wrap_mode) {
+            WrapMode wrap_mode, bool srgb) : m_srgb(srgb) {
         if constexpr (HasGPUTexture) {
+            if (srgb && !IsUInt8)
+                jit_raise("Texture(): the 'srgb' flag is only supported for "
+                          "8-bit (UInt8) textures.");
             void *h = jit_tex_wrap(Backend, handle, Dimension,
                                    (int) type_v<scalar_t<Storage_>>,
                                    (int) writable, (int) filter_mode,
-                                   (int) wrap_mode);
+                                   (int) wrap_mode, (int) m_srgb);
 
             // The native shape is innermost-first (+channels); reverse it into
             // the tensor order that init() expects.
@@ -192,6 +206,7 @@ private:
                  /* external = */ h);
         } else {
             (void) handle; (void) writable; (void) filter_mode; (void) wrap_mode;
+            (void) srgb;
             jit_raise("Texture::from_native_handle() requires the CUDA or Metal "
                       "backend.");
         }
@@ -222,7 +237,11 @@ public:
     /// Was this texture created so that kernels may store into it via \ref write()?
     bool writable() const { return m_writable; }
 
+    /// Are 8-bit samples decoded from sRGB to linear?
+    bool srgb() const { return m_srgb; }
+
     /// Map an imported texture (\ref from_native_handle()) for use by Dr.Jit
+    /// (no-op on Metal, required for CUDA/OpenGL).
     void map() {
         if constexpr (HasGPUTexture)
             jit_tex_map(m_handle);
@@ -413,6 +432,7 @@ public:
         set_value(m_unpadded_value.array(), migrate);
     }
 
+    /// Return the texture data as an array object
     const Storage &value() const { return tensor().array(); }
 
     /// Return the texture data as a tensor object
@@ -576,25 +596,33 @@ public:
     template <typename Value>
     void write(const Array<uint32_array_t<Value>, Dimension> &pos,
                const Value *value, mask_t<Value> active = true) {
-        static_assert(HasGPUTexture,
-                      "Texture::write() requires the CUDA or Metal backend.");
+        static_assert(is_jit_v<Storage_>,
+                      "Texture::write() requires a JIT backend");
         if (!m_writable)
             jit_raise("Texture::write(): texture was not created with "
                       "writable=true.");
 
-        uint32_t pos_idx[Dimension];
-        for (size_t i = 0; i < Dimension; ++i)
-            pos_idx[i] = pos[i].index();
+        if constexpr (HasGPUTexture) {
+            uint32_t pos_idx[Dimension];
+            for (size_t i = 0; i < Dimension; ++i)
+                pos_idx[i] = pos[i].index();
 
-        uint64_t *val_idx = (uint64_t *) alloca(sizeof(uint64_t) * m_channels);
-        for (size_t ch = 0; ch < m_channels; ++ch)
-            val_idx[ch] = (uint64_t) value[ch].index();
+            uint64_t *val_idx = (uint64_t *) alloca(sizeof(uint64_t) * m_channels);
+            for (size_t ch = 0; ch < m_channels; ++ch)
+                val_idx[ch] = (uint64_t) value[ch].index();
 
-        ad_tex_write((uint32_t) m_channels_storage, (uint32_t) m_channels,
-                     m_handle, pos_idx, val_idx, active.index());
+            ad_tex_write((uint32_t) m_channels_storage, (uint32_t) m_channels,
+                         type_v<scalar_t<Storage_>>, (int) m_srgb, m_handle,
+                         pos_idx, val_idx, active.index());
 
-        // The GPU texture object is now the authoritative copy
-        m_migrated = true;
+            // The GPU texture object is now the authoritative copy
+            m_migrated = true;
+        } else {
+            // No hardware texture (LLVM, or double precision): scatter into the
+            // backing storage instead.
+            write_nonaccel(pos, value, active);
+        }
+
         m_tensor_dirty = true;
     }
 
@@ -628,11 +656,6 @@ public:
     /**
      * \brief Fetch the texels that would be referenced in a texture lookup with
      * linear interpolation without actually performing this interpolation.
-     *
-     * On the JIT backends this is performed by the type-erased ``ad_tex_fetch``
-     * kernel in ``libdrjit-extra`` (hardware-accelerated when available, with
-     * the differentiable arithmetic re-attached); the scalar backend uses
-     * \ref eval_fetch_nonaccel().
      */
     template <typename Output>
     Array<Output, (1 << Dimension)>
@@ -654,9 +677,9 @@ public:
                                               m_channels);
             ad_tex_fetch(type_v<scalar_t<Value>>, (uint32_t) Dimension,
                 (uint32_t) m_channels_storage, (uint32_t) m_channels,
-                (int) m_wrap_mode, m_handle, (int) m_use_accel, value_index(),
-                resolution_indices().data(), idiv_indices().data(),
-                pos_indices(pos).data(), active.index(), o);
+                (int) m_wrap_mode, (int) m_srgb, m_handle, (int) m_use_accel,
+                value_index(), resolution_indices().data(),
+                idiv_indices().data(), pos_indices(pos).data(), active.index(), o);
 
             for (size_t c = 0; c < ncorner; ++c)
                 for (size_t ch = 0; ch < m_channels; ++ch)
@@ -737,9 +760,9 @@ public:
             uint64_t *o = (uint64_t *) alloca(sizeof(uint64_t) * m_channels);
             ad_tex_cubic(type_v<scalar_t<Value>>, (uint32_t) Dimension,
                 (uint32_t) m_channels_storage, (uint32_t) m_channels,
-                (int) m_wrap_mode, m_handle, (int) use_accel, value_index(),
-                resolution_indices().data(), idiv_indices().data(),
-                pos_indices(pos).data(), active.index(), o);
+                (int) m_wrap_mode, (int) m_srgb, m_handle, (int) use_accel,
+                value_index(), resolution_indices().data(),
+                idiv_indices().data(), pos_indices(pos).data(), active.index(), o);
 
             for (size_t ch = 0; ch < m_channels; ++ch)
                 out.set_entry(ch, steal_value<Value>(o[ch]));
@@ -854,8 +877,51 @@ public:
 
         gather_packet_dynamic(m_channels_storage, m_value.array(), idx,
                               packet.data(), active);
+        for (uint32_t ch = 0; ch < m_channels; ++ch) {
+            Value v = Value(packet[ch]);
+            // 8-bit storage is gathered as 0..255; normalize (and decode sRGB)
+            // to match the hardware texture units' normalized read. The sRGB
+            // formats leave each RGBA sub-texture's 4th (alpha) channel linear.
+            if constexpr (IsUInt8) {
+                v *= Value(1.f / 255.f);
+                if (m_srgb && (ch % 4) != 3)
+                    v = srgb_to_linear(v);
+            }
+            out[ch] = v;
+        }
+    }
+
+    /// Convert a query-precision value to stored form (the inverse of \ref
+    /// convert_texel): 8-bit storage is sRGB-encoded and quantized to 0..255,
+    /// floating-point storage is a plain cast.
+    template <typename Value>
+    Storage_ store_texel(const Value &v, uint32_t ch) const {
+        if constexpr (IsUInt8) {
+            Value w = clip(v, Value(0), Value(1));
+            if (m_srgb && (ch % 4) != 3)
+                w = linear_to_srgb(w);
+            return Storage_(fmadd(w, Value(255), Value(0.5)));
+        } else {
+            return Storage_(v);
+        }
+    }
+
+    /// Software fallback for \ref write(): scatter the per-channel values into
+    /// the channel-padded backing storage. Used whenever the texture has no
+    /// hardware representation (the LLVM backend, or double precision).
+    template <typename Value>
+    void write_nonaccel(const Array<uint32_array_t<Value>, Dimension> &pos,
+                        const Value *value, mask_t<Value> active) {
+        using UInt = uint32_array_t<Value>;
+
+        // Row-major flat texel index into the [shape..., channels] storage
+        UInt pixel = pos[Dimension - 1];
+        for (size_t i = 1; i < Dimension; ++i)
+            pixel = fmadd(pixel, (uint32_t) m_shape[i], pos[Dimension - 1 - i]);
+        UInt base = pixel * (uint32_t) m_channels_storage;
+
         for (uint32_t ch = 0; ch < m_channels; ++ch)
-            out[ch] = Value(packet[ch]);
+            scatter(m_value.array(), store_texel(value[ch], ch), base + ch, active);
     }
 
 protected:
@@ -865,6 +931,10 @@ protected:
               void *external = nullptr) {
         if (channels == 0)
             jit_raise("Texture::Texture(): must have at least 1 channel!");
+
+        if (m_srgb && !IsUInt8)
+            jit_raise("Texture(): the 'srgb' flag is only supported for 8-bit "
+                      "(UInt8) textures.");
 
         m_writable = writable;
         m_channels = channels;
@@ -932,7 +1002,7 @@ protected:
                     m_handle = jit_tex_create(
                         Backend, Dimension, tex_shape, m_channels_storage,
                         (int) type_v<scalar_t<Storage_>>, (int) filter_mode,
-                        (int) wrap_mode, (int) m_writable);
+                        (int) wrap_mode, (int) m_writable, (int) m_srgb);
                 }
             }
         }
@@ -958,6 +1028,7 @@ private:
         m_wrap_mode = other.m_wrap_mode;
         m_use_accel = other.m_use_accel;
         m_writable = other.m_writable;
+        m_srgb = other.m_srgb;
         m_migrated = other.m_migrated;
         m_tensor_dirty = other.m_tensor_dirty;
     }
@@ -1102,18 +1173,16 @@ private:
         uint64_t *out_idx = (uint64_t *) alloca(sizeof(uint64_t) * m_channels);
         ad_tex_eval(type_v<scalar_t<Value>>, (uint32_t) Dimension,
                     (uint32_t) m_channels_storage, (uint32_t) m_channels,
-                    (int) m_filter_mode, (int) m_wrap_mode, m_handle,
-                    (int) use_accel, value_index(), resolution_indices().data(),
-                    idiv_indices().data(), pos_indices(pos).data(),
-                    active.index(), out_idx);
+                    (int) m_filter_mode, (int) m_wrap_mode, (int) m_srgb,
+                    m_handle, (int) use_accel, value_index(),
+                    resolution_indices().data(), idiv_indices().data(),
+                    pos_indices(pos).data(), active.index(), out_idx);
         for (size_t ch = 0; ch < m_channels; ++ch)
             out.set_entry(ch, steal_value<Value>(out_idx[ch]));
     }
 
     /// Shared marshaller for \ref eval_cubic_grad() / \ref eval_cubic_hessian():
-    /// fills value + gradient (and hessian, when \c out_hessian is non-null),
-    /// dispatching to ``ad_tex_cubic_deriv`` on the JIT backends and the scalar
-    /// B-spline math otherwise.
+    /// fills value + gradient (and hessian, when \c out_hessian is non-null).
     template <typename Output, typename Gradient, typename Hessian>
     void eval_cubic_deriv(const position_for<Output> &pos, mask_for<Output> active,
                           Output &out_value, Gradient &out_gradient,
@@ -1130,7 +1199,7 @@ private:
                                      : nullptr;
             ad_tex_cubic_deriv(type_v<scalar_t<Value>>, (uint32_t) Dimension,
                                (uint32_t) m_channels_storage, (uint32_t) m_channels,
-                               (int) m_wrap_mode, value_index(),
+                               (int) m_wrap_mode, (int) m_srgb, value_index(),
                                resolution_indices().data(), idiv_indices().data(),
                                pos_indices(pos).data(), active.index(), vp, gp, hp);
             // The kernel's flat outputs match this iteration order; walk linearly
@@ -1191,6 +1260,8 @@ private:
     bool m_use_accel = false;
     /// Texture was created so kernels may store into it via write()
     bool m_writable = false;
+    /// 8-bit textures: decode sRGB -> linear on sampling
+    bool m_srgb = false;
     /// Hardware-texture flag: is the data held exclusively on the device?
     mutable bool m_migrated = false;
     /// Does the public-facing unpadded tensor need to be updated?

--- a/include/drjit/texture_impl.h
+++ b/include/drjit/texture_impl.h
@@ -54,6 +54,11 @@ NAMESPACE_BEGIN(detail)
 /// Largest supported texture dimension
 static constexpr uint32_t MaxDim = 3;
 
+/// Holds an ``Ops`` channel count as a compile-time constant (so loops unroll
+/// and scratch can be fixed stack arrays), or a runtime member when ``C == 0``.
+template <uint32_t C> struct ChannelCount { static constexpr uint32_t channels_out = C; };
+template <> struct ChannelCount<0> { uint32_t channels_out; };
+
 /// RAII helper to initialize/destruct an array over caller-supplied storage
 template <typename T> struct tex_scratch {
     DRJIT_NON_COPYABLE(tex_scratch)

--- a/src/extra/texture.cpp
+++ b/src/extra/texture.cpp
@@ -18,6 +18,8 @@
 #include <drjit/extra.h>
 #include <drjit/texture_impl.h>
 #include <drjit/idiv.h>
+#include <drjit/color.h>
+#include <drjit/math.h>
 #include <drjit-core/half.h>
 #include <drjit-core/texture.h>
 
@@ -52,6 +54,29 @@ static Float query_scalar(JitBackend backend, VarType type, double value) {
 /// Cast an AD variable index to the runtime query precision
 static Float to_query(uint64_t index, VarType type) {
     return Float::steal(ad_var_cast(index, type));
+}
+
+/// The type-erased ``Float`` re-tagged with a concrete precision ``T``
+template <typename T> using TypedFloat = dr::DiffArray<JitBackend::None, T>;
+
+/// sRGB -> linear, dispatched to the typed ``dr::srgb_to_linear`` since
+/// ``Float`` is type-erased
+static Float srgb_to_linear(const Float &x, VarType query_type) {
+    auto decode = [](const auto &v) {
+        return Float::steal(dr::srgb_to_linear(v).release());
+    };
+    switch (query_type) {
+        case VarType::Float16: {
+            // Decode in single precision, then cast back
+            Float xf = to_query(x.index_combined(), VarType::Float32);
+            Float yf = decode(TypedFloat<float>::borrow(xf.index_combined()));
+            return to_query(yf.index_combined(), VarType::Float16);
+        }
+        case VarType::Float32: return decode(TypedFloat<float>::borrow(x.index_combined()));
+        case VarType::Float64: return decode(TypedFloat<double>::borrow(x.index_combined()));
+        default: jit_raise("ad_tex_eval(): unsupported query type!");
+    }
+    return Float();
 }
 
 /// Cast ``dim`` query coordinates to single precision (the hardware texture
@@ -89,6 +114,8 @@ struct JitOps {
     uint32_t dim, channels_stored, channels_out;
     dr::FilterMode filter_mode;
     dr::WrapMode wrap_mode;
+    bool unorm8 = false;
+    bool srgb = false;
     uint64_t value;
     Mask active;
     Float res_f_[MaxDim];
@@ -116,13 +143,24 @@ struct JitOps {
                                    ReduceMode::Auto);
 
         finalize_lookup(tmp, channels_stored, channels_out, query_type, out);
+
+        // Map 8-bit values to [0, 1]. For sRGB textures, apply the transfer
+        // curve to linearize. To replicate how GPUs do this, skip every 4th
+        // channel (A in RGBA).
+        if (unorm8) {
+            for (uint32_t ch = 0; ch < channels_out; ++ch) {
+                out[ch] = out[ch] * lit(1.0 / 255.0);
+                if (srgb && (ch % 4) != 3)
+                    out[ch] = srgb_to_linear(out[ch], query_type);
+            }
+        }
     }
 };
 
 /// Create the ``Ops`` object for ``ad_tex_*`` functions.
 static JitOps tex_setup(VarType query_type, uint32_t dim, uint32_t channels_stored,
                         uint32_t channels_out, int filter_mode,
-                        int wrap_mode, uint64_t value,
+                        int wrap_mode, int srgb, uint64_t value,
                         const uint32_t *res_idx, const uint32_t *idiv_idx,
                         const uint64_t *pos_idx, uint32_t active_idx,
                         Float *pos) {
@@ -134,6 +172,8 @@ static JitOps tex_setup(VarType query_type, uint32_t dim, uint32_t channels_stor
     ops.channels_stored = channels_stored;
     ops.filter_mode = (dr::FilterMode) filter_mode;
     ops.wrap_mode = (dr::WrapMode) wrap_mode;
+    ops.unorm8 = jit_var_type((uint32_t) value) == VarType::UInt8;
+    ops.srgb = srgb != 0;
     ops.value = value;
     bool divides = ops.wrap_mode != dr::WrapMode::Clamp;
     for (uint32_t k = 0; k < dim; ++k) {
@@ -193,14 +233,14 @@ static void tex_eval_accel(void *handle,
 } // anonymous namespace
 
 void ad_tex_eval(VarType query_type, uint32_t dim, uint32_t channels_stored,
-                 uint32_t channels_out, int filter_mode, int wrap_mode,
+                 uint32_t channels_out, int filter_mode, int wrap_mode, int srgb,
                  void *handle, int use_accel, uint64_t value,
                  const uint32_t *res_idx, const uint32_t *idiv_idx,
                  const uint64_t *pos_idx, uint32_t active_idx,
                  uint64_t *out_idx) {
     Float pos[MaxDim];
     JitOps ops = tex_setup(query_type, dim, channels_stored, channels_out,
-                             filter_mode, wrap_mode, value, res_idx, idiv_idx,
+                             filter_mode, wrap_mode, srgb, value, res_idx, idiv_idx,
                              pos_idx, active_idx, pos);
 
     bool accel = handle != nullptr && use_accel;
@@ -231,14 +271,14 @@ void ad_tex_eval(VarType query_type, uint32_t dim, uint32_t channels_stored,
 }
 
 void ad_tex_fetch(VarType query_type, uint32_t dim, uint32_t channels_stored,
-                  uint32_t channels_out, int wrap_mode, void *handle,
+                  uint32_t channels_out, int wrap_mode, int srgb, void *handle,
                   int use_accel, uint64_t value, const uint32_t *res_idx,
                   const uint32_t *idiv_idx, const uint64_t *pos_idx,
                   uint32_t active_idx, uint64_t *out_idx) {
     Float pos[MaxDim];
     JitOps ops = tex_setup(query_type, dim, channels_stored, channels_out,
-                             (int) dr::FilterMode::Linear, wrap_mode, value, res_idx,
-                             idiv_idx, pos_idx, active_idx, pos);
+                             (int) dr::FilterMode::Linear, wrap_mode, srgb, value,
+                             res_idx, idiv_idx, pos_idx, active_idx, pos);
 
     uint32_t ncorner = 1u << dim;
 
@@ -334,14 +374,14 @@ void ad_tex_wrap(uint32_t dim, int wrap_mode, const uint32_t *res_idx,
 }
 
 void ad_tex_cubic(VarType query_type, uint32_t dim, uint32_t channels_stored,
-                  uint32_t channels_out, int wrap_mode, void *handle,
+                  uint32_t channels_out, int wrap_mode, int srgb, void *handle,
                   int use_accel, uint64_t value, const uint32_t *res_idx,
                   const uint32_t *idiv_idx, const uint64_t *pos_idx,
                   uint32_t active_idx, uint64_t *out_idx) {
     Float pos[MaxDim];
     JitOps ops = tex_setup(query_type, dim, channels_stored, channels_out,
-                             (int) dr::FilterMode::Linear, wrap_mode, value, res_idx,
-                             idiv_idx, pos_idx, active_idx, pos);
+                             (int) dr::FilterMode::Linear, wrap_mode, srgb, value,
+                             res_idx, idiv_idx, pos_idx, active_idx, pos);
 
     bool accel = (handle != nullptr && use_accel);
 
@@ -399,9 +439,10 @@ void ad_tex_cubic(VarType query_type, uint32_t dim, uint32_t channels_stored,
         for (uint32_t ch = 0; ch < channels_out; ++ch)
             result[ch] = f[ch];
 
-        // The transform is non-linear in `pos`, so replace its AD graph with a
-        // direct B-spline evaluation when gradient tracking is on (``f`` is free
-        // after the reduction, so reuse it for the recompute).
+        // The coordinate warp is non-linear in `pos`, so its AD graph gives the
+        // wrong derivative. When gradients are tracked, recompute via the
+        // directly-differentiable B-spline path and splice its gradient onto the
+        // fast primal with replace_grad() (reusing the now-dead `f` as scratch).
         if (any_grad(value, pos_idx, dim)) {
             Float *scratch_mem = (Float *) alloca(sizeof(Float) * channels_out);
             tex_scratch<Float> scratch(scratch_mem, channels_out);
@@ -416,15 +457,15 @@ void ad_tex_cubic(VarType query_type, uint32_t dim, uint32_t channels_stored,
 }
 
 void ad_tex_cubic_deriv(VarType query_type, uint32_t dim, uint32_t channels_stored,
-                        uint32_t channels_out, int wrap_mode,
+                        uint32_t channels_out, int wrap_mode, int srgb,
                         uint64_t value, const uint32_t *res_idx,
                         const uint32_t *idiv_idx, const uint64_t *pos_idx,
                         uint32_t active_idx, uint64_t *out_value,
                         uint64_t *out_grad, uint64_t *out_hess) {
     Float pos[MaxDim];
     JitOps ops = tex_setup(query_type, dim, channels_stored, channels_out,
-                             (int) dr::FilterMode::Linear, wrap_mode, value, res_idx,
-                             idiv_idx, pos_idx, active_idx, pos);
+                             (int) dr::FilterMode::Linear, wrap_mode, srgb, value,
+                             res_idx, idiv_idx, pos_idx, active_idx, pos);
 
     bool want_hess = out_hess != nullptr;
     Float *value_mem = (Float *) alloca(sizeof(Float) * channels_out);
@@ -449,20 +490,34 @@ void ad_tex_cubic_deriv(VarType query_type, uint32_t dim, uint32_t channels_stor
             out_hess[i] = hess_out[i].release();
 }
 
-void ad_tex_write(uint32_t channels_stored, uint32_t channels_out, void *handle,
+void ad_tex_write(uint32_t channels_stored, uint32_t channels_out,
+                  VarType storage_type, int srgb, void *handle,
                   const uint32_t *pos_idx, const uint64_t *value,
                   uint32_t active_idx) {
     using F32 = GenericArray<float>;
-    jit_set_backend(pos_idx[0]);
+    JitBackend backend = jit_set_backend(pos_idx[0]).backend;
+
+    // CUDA stores 8-bit textures as raw unorm8 bytes, so clip and sRGB-encode in
+    // software (codegen scales to 0..255); Metal does this in hardware.
+    bool quantize = backend == JitBackend::CUDA &&
+                    storage_type == VarType::UInt8;
 
     F32 *vals_mem = (F32 *) alloca(sizeof(F32) * channels_stored);
     tex_scratch<F32> vals(vals_mem, channels_stored);
     uint32_t *val_idx = (uint32_t *) alloca(channels_stored * sizeof(uint32_t));
     for (uint32_t ch = 0; ch < channels_stored; ++ch) {
-        vals[ch] = ch < channels_out
-                       ? F32::steal(jit_var_cast((uint32_t) value[ch],
-                                                 VarType::Float32, 0))
-                       : dr::zeros<F32>();
+        if (ch < channels_out) {
+            F32 v = F32::steal(jit_var_cast((uint32_t) value[ch],
+                                            VarType::Float32, 0));
+            if (quantize) {
+                v = dr::clip(v, 0.f, 1.f);
+                if (srgb && (ch % 4) != 3)
+                    v = dr::linear_to_srgb(v);
+            }
+            vals[ch] = v;
+        } else {
+            vals[ch] = dr::zeros<F32>();
+        }
         val_idx[ch] = vals[ch].index();
     }
 

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -7045,6 +7045,13 @@
     defines the wrapping method. The default behavior is ``drjit.WrapMode.Clamp``,
     which indefinitely extends the colors on the boundary along each dimension.
 
+    On the CUDA and Metal backends, hardware texture units resolve the sub-texel
+    position using reduced-precision fixed-point weights (8 fractional bits on
+    CUDA, i.e. 256 steps between texels). This does not degrade the stored values
+    or the interpolated quantity, only how finely the fractional position within
+    a texel is resolved. Set ``use_accel=False`` to disable the texture units and
+    avoid this approximation at some cost in performance.
+
     For 8-bit textures, setting ``srgb`` additionally requests that samples be
     decoded from sRGB to linear. Passing it for a floating-point texture raises
     an error. Channels are grouped into hardware RGBA quads, so within each group

--- a/src/python/docstr.rst
+++ b/src/python/docstr.rst
@@ -7045,6 +7045,12 @@
     defines the wrapping method. The default behavior is ``drjit.WrapMode.Clamp``,
     which indefinitely extends the colors on the boundary along each dimension.
 
+    For 8-bit textures, setting ``srgb`` additionally requests that samples be
+    decoded from sRGB to linear. Passing it for a floating-point texture raises
+    an error. Channels are grouped into hardware RGBA quads, so within each group
+    of four the first three are decoded and the fourth (alpha) is left linear
+    (e.g. channel 3 is linear for a 6-channel texture).
+
 .. topic:: Texture_init_tensor
 
     Construct a new texture from a given tensor
@@ -7126,11 +7132,11 @@
 
 .. topic:: Texture_filter_mode
 
-    Return the filter mode
+    Return the texture filtering mode (e.g., nearest, bilinear, etc.)
 
 .. topic:: Texture_wrap_mode
 
-    Return the wrap mode
+    Return the boundary handling mode for out-of-bounds lookups
 
 .. topic:: Texture_wrap
 
@@ -7138,14 +7144,11 @@
 
 .. topic:: Texture_use_accel
 
-    Return whether texture uses the GPU for storage and evaluation
+    Are hardware texture units used for evaluation?
 
 .. topic:: Texture_migrated
 
-    Return whether textures with :py:func:`use_accel()` set to ``True`` only store
-    the data as a hardware-accelerated GPU texture.
-
-    If ``False`` then a copy of the array data will additionally be retained .
+    Is the texture data held exclusively in GPU texture memory?
 
 .. topic:: Texture_shape
 
@@ -7227,6 +7230,10 @@
     Was this texture created so that kernels may store into it via
     :py:func:`write()`?
 
+.. topic:: Texture_srgb
+
+    Are 8-bit samples decoded from sRGB to linear?
+
 .. topic:: Texture_write
 
     Store values into a writable hardware texture
@@ -7261,8 +7268,8 @@
 
 .. topic:: Texture_map
 
-    Map a :py:func:`from_native_handle()` texture for use by Dr.Jit (no-op on
-    Metal, required for CUDA/OpenGL).
+    Map an imported texture (:py:func:`from_native_handle()`) for use by Dr.Jit
+    (no-op on Metal, required for CUDA/OpenGL).
 
 .. topic:: Texture_unmap
 

--- a/src/python/texture.h
+++ b/src/python/texture.h
@@ -159,37 +159,38 @@ static void tex_write(Tex &texture,
     if (value.size() != channels)
         nb::raise("Texture.write(): expected %zu channel values, got %zu.",
                   channels, value.size());
-    if constexpr (Tex::HasGPUTexture)
+    if constexpr (dr::is_jit_v<typename Tex::Storage>)
         texture.write(pos, value.data(), active);
     else
-        nb::raise("Texture.write(): requires a CUDA or Metal "
-                  "float16/float32 texture.");
+        nb::raise("Texture.write(): requires a JIT backend (CUDA, Metal, or LLVM).");
 }
 
-template <typename Type, size_t Dimension>
+template <typename Type, size_t Dimension, typename QueryArray = Type>
 void bind_texture(nb::module_ &m, const char *name) {
     using Tex = dr::Texture<Type, Dimension>;
-    using Float16 = dr::replace_scalar_t<Type, dr::half>;
-    using Float32 = dr::replace_scalar_t<Type, float>;
-    using Float64 = dr::replace_scalar_t<Type, double>;
+    // Query/output precisions; for 8-bit textures these come from a separate
+    // floating-point guide (\c QueryArray) since the storage type is integral.
+    using Float16 = dr::replace_scalar_t<QueryArray, dr::half>;
+    using Float32 = dr::replace_scalar_t<QueryArray, float>;
+    using Float64 = dr::replace_scalar_t<QueryArray, double>;
 
     auto tex = nb::class_<Tex>(m, name)
         .def("__init__", [](Tex* t, const dr::vector<size_t>& shape,
                          size_t channels, bool use_accel,
                          dr::FilterMode filter_mode, dr::WrapMode wrap_mode,
-                         bool writable) {
+                         bool writable, bool srgb) {
                  new (t) Tex(shape.data(), channels, use_accel, filter_mode,
-                             wrap_mode, writable); },
+                             wrap_mode, writable, srgb); },
              "shape"_a, "channels"_a, "use_accel"_a = true,
              "filter_mode"_a = dr::FilterMode::Linear,
              "wrap_mode"_a = dr::WrapMode::Clamp,
-             "writable"_a = false,
+             "writable"_a = false, "srgb"_a = false,
              doc_Texture_init)
         .def(nb::init<const typename Tex::TensorXf &, bool, bool, dr::FilterMode,
-                      dr::WrapMode>(),
+                      dr::WrapMode, bool>(),
              "tensor"_a, "use_accel"_a = true, "migrate"_a = true,
              "filter_mode"_a = dr::FilterMode::Linear,
-             "wrap_mode"_a = dr::WrapMode::Clamp,
+             "wrap_mode"_a = dr::WrapMode::Clamp, "srgb"_a = false,
              doc_Texture_init_tensor)
         .def("set_value",
              &Tex::template set_value<const typename Tex::Storage &>,
@@ -214,10 +215,11 @@ void bind_texture(nb::module_ &m, const char *name) {
              doc_Texture_wrap)
         .def("use_accel", &Tex::use_accel, doc_Texture_use_accel)
         .def("writable", &Tex::writable, doc_Texture_writable)
+        .def("srgb", &Tex::srgb, doc_Texture_srgb)
         .def_static("from_native_handle", &Tex::from_native_handle, "handle"_a,
              "writable"_a = false,
              "filter_mode"_a = dr::FilterMode::Linear,
-             "wrap_mode"_a = dr::WrapMode::Clamp,
+             "wrap_mode"_a = dr::WrapMode::Clamp, "srgb"_a = false,
              doc_Texture_from_native_handle)
         .def("map", &Tex::map, doc_Texture_map)
         .def("unmap", &Tex::unmap, doc_Texture_unmap)
@@ -262,6 +264,9 @@ void bind_texture_all(nb::module_ &m) {
     using Type16 = dr::float16_array_t<Type>;
     using Type32 = dr::float32_array_t<Type>;
     using Type64 = dr::float64_array_t<Type>;
+    // 8-bit storage is integral; queries still return single precision via the
+    // \c Type32 guide (differentiable in the AD variants).
+    using Type8 = dr::uint8_array_t<Type>;
     bind_texture<Type16, 1>(m, "Texture1f16");
     bind_texture<Type16, 2>(m, "Texture2f16");
     bind_texture<Type16, 3>(m, "Texture3f16");
@@ -271,6 +276,9 @@ void bind_texture_all(nb::module_ &m) {
     bind_texture<Type64, 1>(m, "Texture1f64");
     bind_texture<Type64, 2>(m, "Texture2f64");
     bind_texture<Type64, 3>(m, "Texture3f64");
+    bind_texture<Type8, 1, Type32>(m, "Texture1f8u");
+    bind_texture<Type8, 2, Type32>(m, "Texture2f8u");
+    bind_texture<Type8, 3, Type32>(m, "Texture3f8u");
 }
 
 #undef DR_TEX_DISPATCH

--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -9,10 +9,6 @@ def _skip_metal_f64(t, texture_type):
     if dr.backend_v(t) == dr.JitBackend.Metal and 'f64' in texture_type:
         pytest.skip("Metal does not support float64")
 
-def _skip_non_hw_write(t):
-    if dr.backend_v(t) not in (dr.JitBackend.CUDA, dr.JitBackend.Metal):
-        pytest.skip("hardware texture writes require the CUDA or Metal backend")
-
 @pytest.mark.parametrize("wrap_mode", wrap_modes)
 @pytest.mark.parametrize("force_optix", [True, False])
 @pytest.mark.parametrize("texture_type", ['Texture1f64', 'Texture1f', 'Texture1f16'])
@@ -984,7 +980,6 @@ def test27_masked(t, texture_type):
 def test28_write_flag(t, texture_type):
     # Writable textures expose write(); a non-writable one rejects it; and a
     # writable texture can be *both* written and sampled.
-    _skip_non_hw_write(t)
     mod = sys.modules[t.__module__]
     TexType = getattr(mod, texture_type)
     UInt32 = dr.uint32_array_t(t)
@@ -1020,11 +1015,10 @@ def test28_write_flag(t, texture_type):
 @pytest.mark.parametrize("texture_type", ['Texture2f', 'Texture2f16'])
 @pytest.test_arrays("is_jit, float32, shape=(*)")
 def test29_write_read(t, texture_type):
-    # Per-pixel hardware stores round-trip through the texture for every channel
+    # Per-pixel stores round-trip through the texture for every channel
     # count (exercises the 1/2/4-channel sub-texture split and padding). The
     # value written at pixel `idx`, channel `c` is `(idx*ch + c)*0.01`, so the
     # interleaved read-back tensor must equal `arange(H*W*ch)*0.01`.
-    _skip_non_hw_write(t)
     mod = sys.modules[t.__module__]
     TexType = getattr(mod, texture_type)
     UInt32 = dr.uint32_array_t(t)
@@ -1047,7 +1041,6 @@ def test29_write_read(t, texture_type):
 @pytest.test_arrays("is_jit, float32, shape=(*)")
 def test30_write_masked(t, texture_type):
     # A masked store updates only the active lanes.
-    _skip_non_hw_write(t)
     mod = sys.modules[t.__module__]
     TexType = getattr(mod, texture_type)
     UInt32 = dr.uint32_array_t(t)
@@ -1071,8 +1064,7 @@ def test30_write_masked(t, texture_type):
 @pytest.mark.parametrize("texture_type", ['Texture3f', 'Texture3f16'])
 @pytest.test_arrays("is_jit, float32, shape=(*)")
 def test31_write_3d(t, texture_type):
-    # 3D hardware stores round-trip.
-    _skip_non_hw_write(t)
+    # 3D stores round-trip.
     mod = sys.modules[t.__module__]
     TexType = getattr(mod, texture_type)
     UInt32 = dr.uint32_array_t(t)
@@ -1153,3 +1145,149 @@ def test32_from_native_handle(t, texture_type):
     # A non-writable texture cannot be wrapped for writing.
     with pytest.raises(Exception):
         TexType.from_native_handle(src.native_handle(), writable=True)
+
+
+def _srgb_to_linear(u):
+    x = u / 255.0
+    return x / 12.92 if x <= 0.04045 else ((x + 0.055) / 1.055) ** 2.4
+
+
+@pytest.mark.parametrize("srgb", [False, True])
+@pytest.mark.parametrize("channels", [1, 3, 5])
+@pytest.test_arrays("is_jit, float32, shape=(*)")
+def test33_uint8(t, channels, srgb):
+    # 8-bit textures normalize their 0..255 storage to [0, 1] on lookup,
+    # optionally decoding sRGB. Pin the exact normalized value via a nearest
+    # lookup, and require the hardware and arithmetic paths to agree.
+    mod = sys.modules[t.__module__]
+    TexType = getattr(mod, 'Texture2f8u')
+    UInt8 = getattr(mod, 'UInt8')
+    Array2f = getattr(mod, 'Array2f')
+
+    H, W = 4, 5
+    vals = [(i * 37 + ch * 53) % 256
+            for i in range(H * W) for ch in range(channels)]
+    data = mod.TensorXu8(UInt8(vals), shape=(H, W, channels))
+
+    tex = TexType(data, use_accel=True, migrate=False, srgb=srgb)
+    tex_soft = TexType(data, use_accel=False, srgb=srgb)
+    tex_near = TexType(data, use_accel=False, srgb=srgb,
+                       filter_mode=dr.FilterMode.Nearest)
+    assert tex.srgb() == srgb
+
+    # Nearest lookup at the first texel's center returns its (decoded) value.
+    # sRGB decoding (like the hardware) skips each RGBA group's alpha channel.
+    out0 = tex_near.eval(Array2f(0.5 / W, 0.5 / H))
+    for ch in range(channels):
+        ref = (_srgb_to_linear(vals[ch]) if srgb and ch % 4 != 3
+               else vals[ch] / 255.0)
+        assert dr.allclose(out0[ch], ref, 1e-3, 1e-3)
+
+    # Hardware and arithmetic linear lookups agree
+    pos = Array2f([0.2, 0.55, 0.9], [0.3, 0.6, 0.8])
+    out_soft, out_accel = tex_soft.eval(pos), tex.eval(pos)
+    for ch in range(channels):
+        assert dr.allclose(out_soft[ch], out_accel[ch], 5e-3, 5e-3)
+
+
+@pytest.test_arrays("is_diff, float32, shape=(*)")
+def test34_uint8_eval_variants(t):
+    # The full lookup surface (fetch / cubic / their derivatives) normalizes
+    # 8-bit storage like eval(), and the hardware and arithmetic paths agree.
+    mod = sys.modules[t.__module__]
+    TexType = getattr(mod, 'Texture2f8u')
+    UInt8 = getattr(mod, 'UInt8')
+    Array2f = getattr(mod, 'Array2f')
+
+    H, W, C = 5, 6, 3
+    vals = [(i * 29 + ch * 71) % 256
+            for i in range(H * W) for ch in range(C)]
+    data = mod.TensorXu8(UInt8(vals), shape=(H, W, C))
+    tex = TexType(data, use_accel=True, migrate=False)
+    tex_soft = TexType(data, use_accel=False)
+    pos = Array2f([0.3, 0.6], [0.4, 0.7])
+
+    # eval_fetch: each corner is normalized, and the paths agree
+    fa, fs = tex.eval_fetch(pos), tex_soft.eval_fetch(pos)
+    for corner in range(4):
+        for ch in range(C):
+            assert dr.all((fs[corner][ch] >= 0) & (fs[corner][ch] <= 1))
+            assert dr.allclose(fa[corner][ch], fs[corner][ch], 5e-3, 5e-3)
+
+    # eval_cubic: hardware and arithmetic agree
+    ca, cs = tex.eval_cubic(pos), tex_soft.eval_cubic(pos)
+    for ch in range(C):
+        assert dr.allclose(ca[ch], cs[ch], 5e-3, 5e-3)
+
+    # eval_cubic_grad / eval_cubic_hessian run and produce finite results
+    _, grad = tex_soft.eval_cubic_grad(pos)
+    _, _, hess = tex_soft.eval_cubic_hessian(pos)
+    assert dr.all(dr.isfinite(dr.ravel(grad[0])), axis=None)
+    assert dr.all(dr.isfinite(dr.ravel(hess[0])), axis=None)
+
+
+@pytest.mark.parametrize("use_accel", [False, True])
+@pytest.test_arrays("is_diff, float32, shape=(*)")
+def test35_uint8_grad(t, use_accel):
+    # An 8-bit lookup is differentiable w.r.t. the (continuous) query position,
+    # but its integer storage carries no gradient.
+    if use_accel and dr.backend_v(t) not in (dr.JitBackend.CUDA, dr.JitBackend.Metal):
+        pytest.skip("hardware textures require the CUDA or Metal backend")
+    mod = sys.modules[t.__module__]
+    TexType = getattr(mod, 'Texture2f8u')
+    UInt8 = getattr(mod, 'UInt8')
+    Array2f = getattr(mod, 'Array2f')
+
+    H, W, C = 4, 4, 2
+    vals = [(i * 17 + ch * 91) % 256
+            for i in range(H * W) for ch in range(C)]
+    data = mod.TensorXu8(UInt8(vals), shape=(H, W, C))
+
+    # Integer storage cannot be made differentiable
+    assert not dr.grad_enabled(data.array)
+
+    tex = TexType(data, use_accel=use_accel, migrate=False)
+    pos = Array2f(0.5, 0.5)
+    dr.enable_grad(pos)
+    out = tex.eval(pos)
+    dr.backward(out[0] + out[1])
+    g = dr.grad(pos)
+    assert dr.all(dr.isfinite(g))
+
+
+@pytest.test_arrays("is_jit, float32, shape=(*)")
+def test36_uint8_write(t):
+    # write() to an 8-bit texture quantizes [0, 1] floats to normalized storage,
+    # sRGB-encoding when requested (leaving each RGBA group's alpha linear), so a
+    # sampled read round-trips the written value. Metal's unorm/sRGB pixel format
+    # converts in hardware; CUDA and LLVM do it in software.
+    mod = sys.modules[t.__module__]
+    TexType = getattr(mod, 'Texture2f8u')
+    UInt32 = dr.uint32_array_t(t)
+    Array2u = getattr(mod, 'Array2u')
+    Array2f = getattr(mod, 'Array2f')
+
+    H, W = 4, 4
+    for srgb in (False, True):
+        for ch in (1, 3, 4):
+            tex = TexType([H, W], ch, use_accel=True, writable=True,
+                          filter_mode=dr.FilterMode.Nearest, srgb=srgb)
+            idx = dr.arange(UInt32, H * W)
+            vals = [t(idx * ch + c) * (1.0 / (H * W * ch)) for c in range(ch)]
+            tex.write(Array2u(idx % W, idx // W), vals)
+            dr.eval()
+            for i in (0, H * W // 2, H * W - 1):
+                out = tex.eval(Array2f((i % W + 0.5) / W, (i // W + 0.5) / H))
+                for c in range(ch):
+                    v = (i * ch + c) / (H * W * ch)
+                    assert dr.allclose(out[c], v, atol=7e-3)
+
+    # The encoding actually happens: mid-gray 0.5 stores 128 linearly but 188 in
+    # sRGB, while an RGBA group's alpha channel stays linear either way.
+    def stored(srgb):
+        tex = TexType([1, 1], 4, use_accel=True, writable=True, srgb=srgb)
+        tex.write(Array2u(0, 0), [t(0.5)] * 4)
+        dr.eval()
+        return [int(x) for x in tex.value()]
+    assert stored(False) == [128, 128, 128, 128]
+    assert stored(True) == [188, 188, 188, 128]


### PR DESCRIPTION
This PR bundles two improvements to the ``Texture`` class:

## Add unsigned 8-bit texture support

This commit adds texture types like ``Texture2fu8``, which are backed by an unsigned 8-bit representation. Their ``eval_*`` members return normalized floats on the interval ``[0, 1]``. An optional ``srgb=True`` flag can be set to further apply the sRGB to linear transfer curve during evaluation.

All of these features directly map onto hardware texture units on CUDA/Metal. They are explicitly computed on the LLVM/scalar path.

The ``write()`` functions handles 8-bit targets by quantizing and (if needed) sRGB-encoding the inputs.


## Specialize texture evaluation for static channel counts

This commit introduces a small code improvement that mainly accelerates scalar texture evaluation. Previously, ``texture.h`` used ``alloca()`` to reserve a dynamic memory for an unknown number of channels. However, as of commit e749b0d3d, return values are actually typed and provide the exact channel count unless a dynamic array is requested.

This can be used to remove the ``alloca()`` and specialize to the statically known channel count, which improves the quality of the generated code.

The commit also includes touch-ups to a few comments.