### PR TITLE
Fix CMake installs for C++-only builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,9 +209,21 @@ endif()
 if (DRJIT_MASTER_PROJECT)
   install(DIRECTORY include/drjit DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-  install(TARGETS drjit-core EXPORT drjitTargets DESTINATION drjit)
-  install(TARGETS drjit-extra EXPORT drjitTargets DESTINATION drjit)
-  install(TARGETS nanothread EXPORT drjitTargets DESTINATION drjit)
+  if (DRJIT_ENABLE_JIT)
+    if (DRJIT_ENABLE_PYTHON)
+      install(TARGETS drjit-core EXPORT drjitTargets DESTINATION drjit)
+      install(TARGETS drjit-extra EXPORT drjitTargets DESTINATION drjit)
+      install(TARGETS nanothread EXPORT drjitTargets DESTINATION drjit)
+    else()
+      install(
+        TARGETS drjit-core drjit-extra nanothread
+        EXPORT drjitTargets
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      )
+    endif()
+  endif()
 
   if (DRJIT_ENABLE_PYTHON)
     install(TARGETS drjit-python DESTINATION drjit)


### PR DESCRIPTION
## Motivation

C++-only and header-only builds should install a conventional CMake package:

- With every JIT backend disabled, install rules must not reference JIT targets that were never created.
- With JIT enabled and Python disabled, libraries belong in the standard CMake runtime and library directories rather than the Python package directory.

Installing public `drjit-core` headers without JIT is intentionally handled separately in #527. This PR corresponds to conda-forge's [`0002-Fix-install-destination-paths.patch`](https://github.com/conda-forge/drjit-cpp-feedstock/blob/15bc7e077faecf9097ca897dea4252fb06bc6b17/recipe/patches/drjit/0002-Fix-install-destination-paths.patch). Once this change is included in an upstream release, the feedstock can remove that patch.

## Changes

- Guard `drjit-core`, `drjit-extra`, and `nanothread` target installation with `DRJIT_ENABLE_JIT`.
- Use `CMAKE_INSTALL_BINDIR` and `CMAKE_INSTALL_LIBDIR` when Python is disabled.
- Preserve the existing `drjit/` library layout when Python is enabled.

This PR does not move public headers or change Python stub generation or installation.

## Testing

- `git diff --check`
- No-JIT/no-Python configure, build, and install passed.
- LLVM 21 C++ configure, build, and install placed `drjit-core`, `drjit-extra`, and `nanothread` under `lib/`, not `drjit/`.
- An external `find_package(drjit)` consumer built successfully; the installed-header smoke test and live LLVM test both passed.
- Python 3.13 + LLVM 21 configure, build, and install; `drjit` and `drjit.auto` imported, a live LLVM calculation passed, all generated stubs were installed, and libraries remained under `drjit/`.