### PR TITLE
Fix cumulative sum over a tuple of axes only applying one axis

### DIFF
--- a/src/python/reduce.cpp
+++ b/src/python/reduce.cpp
@@ -653,7 +653,7 @@ static nb::object prefix_reduce(ReduceOp op, nb::handle h, nb::handle axis, bool
         nb::object o = nb::borrow(h);
         nb::tuple t = nb::cast<nb::tuple>(axis);
         for (size_t i = 0, s = t.size(); i < s; ++i)
-            o = prefix_reduce(op, h, t[s - 1 - i], exclusive, reverse);
+            o = prefix_reduce(op, o, t[s - 1 - i], exclusive, reverse);
         return o;
     }
     int axis_i;

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -382,6 +382,10 @@ def test08_prefix_sum(t):
     assert dr.all(dr.prefix_sum(x) == [0, 3, 6, 9])
     assert dr.all(dr.cumsum(x) == [3, 6, 9, 12])
 
+    A = m.TensorXf([[1, 2, 3], [4, 5, 6]])
+    assert dr.all(dr.cumsum(A, axis=(0, 1)) == m.TensorXf([[1, 3, 6], [5, 12, 21]]))
+    assert dr.all(dr.prefix_sum(A, axis=(0, 1)) == m.TensorXf([[0, 0, 0], [0, 1, 3]]))
+
 
 @pytest.test_arrays('shape=(*), bool')
 def test09_compress(t):


### PR DESCRIPTION
The tuple-axis loop re-reduced the original input instead of accumulating, so only the last axis was applied. Added a regression test.