### PR TITLE
Fix 2D dynamic slice

### DIFF
--- a/src/python/slice.cpp
+++ b/src/python/slice.cpp
@@ -460,7 +460,10 @@ PyObject *mp_subscript(PyObject *self, PyObject *key) noexcept {
             } else {
                 ArrayMeta m2 = s;
                 m2.shape[0] = (uint8_t) (slicelen <= 4 ? slicelen : DRJIT_DYNAMIC);
-                nb::object result = meta_get_type(m2)();
+                dr::vector<size_t> shape;
+                shape_impl(self, shape);
+                shape[0] = slicelen;
+                nb::object result = full("empty", meta_get_type(m2), nb::handle(), shape);
                 for (size_t i = 0; i < slicelen; ++i)
                     result[i] = nb::handle(self)[start + step * i];
                 return result.release().ptr();

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -207,3 +207,11 @@ def test16_nested_slice_assignment(t):
     x = dr.ones(t, (3, 20))
     x[:-1, 1:100:2] = 2
     assert dr.any(x == 2, axis=None)
+
+
+@pytest.test_arrays('shape=(*, *), float32')
+def test17_2d_slice_get_dynamic_size(t):
+    b = t([1.0], [2.0], [3.0], [4.0], [5.0], [6.0], [7.0], [8.0], [9.0])
+    b3 = b[3:]
+    assert len(b3) == 6
+    assert dr.all(b3 == [[4.0], [5.0], [6.0], [7.0], [8.0], [9.0]])


### PR DESCRIPTION
There appears to be an edge case 2D slices of dynamic size. This PR adds a fix and a test that triggers the issue on the current master. The test suite previously did not cover slices that are larger than 4 elements and trigger the "dynamic" size case.

I am a bit unsure about the fix (AI + manual inspection), but these days it feels a bit silly to open an issue without trying to attempt to fix. 