### PR TITLE
Install drjit-core headers without JIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,7 @@ endif()
 
 if (DRJIT_MASTER_PROJECT)
   install(DIRECTORY include/drjit DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(DIRECTORY ext/drjit-core/include/drjit-core DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
   install(TARGETS drjit-core EXPORT drjitTargets DESTINATION drjit)
   install(TARGETS drjit-extra EXPORT drjitTargets DESTINATION drjit)
@@ -280,7 +281,6 @@ if (DRJIT_MASTER_PROJECT)
   endif()
 
   if (DRJIT_ENABLE_JIT)
-    install(DIRECTORY ext/drjit-core/include/drjit-core DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     install(DIRECTORY ext/drjit-core/ext/nanothread/include/nanothread DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
   endif()
 


### PR DESCRIPTION
## Motivation

Header-only Dr.Jit installations currently omit the public `drjit-core` headers when every JIT backend is disabled. Public Dr.Jit headers include files such as `drjit-core/half.h` and `drjit-core/jit.h`, so the installed header set is incomplete in that configuration.

The missing-target guard and C++ library destinations are intentionally handled separately in #519. This PR corresponds to conda-forge's [`0001-Install-drjit-core-headers.patch`](https://github.com/conda-forge/drjit-cpp-feedstock/blob/15bc7e077faecf9097ca897dea4252fb06bc6b17/recipe/patches/drjit/0001-Install-drjit-core-headers.patch). Once this change is included in an upstream release, the feedstock can remove that patch.

## Changes

- Install the public `drjit-core` headers whenever the top-level Dr.Jit project is installed.
- Keep `nanothread` headers conditional on JIT support.

This PR does not change target installation or library destinations; those changes remain in #519.

## Testing

- `git diff --check`
- No-JIT/no-Python configure, build, and install with temporary interface targets supplied through `CMAKE_PROJECT_INCLUDE` to isolate the unrelated missing-target issue handled by #519.
- The [`85b86aa8`](https://github.com/mitsuba-renderer/drjit/commit/85b86aa8e639e0bf8b15d83633ad59eae11a2edb) negative control omitted `include/drjit-core/half.h`; this branch installed `include/drjit-core/half.h` and `include/drjit-core/macros.h`.
- An external `find_package(drjit)` consumer built and passed the installed-header `half_smoke` test.