### PR TITLE
Fix reversed operands in cooperative vector __rsub__

### DIFF
--- a/src/python/coop_vec.cpp
+++ b/src/python/coop_vec.cpp
@@ -578,7 +578,8 @@ void export_coop_vec(nb::module_ &m) {
              nb::sig("def __radd__(self, arg: CoopVec[T] | T | float | int, /) -> CoopVec[T]"))
         .def("__sub__", &coop_vec_binary_op<JitOp::Sub>,
              nb::sig("def __sub__(self, arg: CoopVec[T] | T | float | int, /) -> CoopVec[T]"))
-        .def("__rsub__", &coop_vec_binary_op<JitOp::Sub>,
+        .def("__rsub__",
+             [](nb::handle h0, nb::handle h1) { return coop_vec_binary_op<JitOp::Sub>(h1, h0); },
              nb::sig("def __rsub__(self, arg: CoopVec[T] | T | float | int, /) -> CoopVec[T]"))
         .def("__mul__", &coop_vec_binary_op<JitOp::Mul>,
              nb::sig("def __mul__(self, arg: CoopVec[T] | T | float | int, /) -> CoopVec[T]"))

--- a/tests/test_coop_vec.py
+++ b/tests/test_coop_vec.py
@@ -41,6 +41,11 @@ def test02_add_sub(t, size):
     dr.schedule(r0, r1)
     assert dr.all((r0 == 18) & (r1 == 19))
 
+    # Reflected subtraction
+    r0, r1 = list(30 - x)[0:2]
+    dr.schedule(r0, r1)
+    assert dr.all((r0 == 25) & (r1 == 24))
+
 @pytest.mark.parametrize('size', [0, 20, 100])
 @pytest.test_arrays('jit,float16,shape=(*),-diff', 'jit,float32,shape=(*),-diff')
 def test03_min_max_fma_dot_abs(t, size):


### PR DESCRIPTION
`__rsub__` used the same function as `__sub__` without swapping the operands, so `5.0 - vec` quietly evaluated to `vec - 5.0` instead.