### PR TITLE
Add missing NEON trunc_() overload for float32x4/float64x2

### DIFF
--- a/include/drjit/packet_neon.h
+++ b/include/drjit/packet_neon.h
@@ -186,6 +186,7 @@ template <bool IsMask_, typename Derived_> struct alignas(16)
     DRJIT_INLINE Derived round_()    const { return vrndnq_f32(m);     }
     DRJIT_INLINE Derived floor_()    const { return vrndmq_f32(m);     }
     DRJIT_INLINE Derived ceil_()     const { return vrndpq_f32(m);     }
+    DRJIT_INLINE Derived trunc_()    const { return vrndq_f32(m);      }
 #endif
 
     DRJIT_INLINE Derived sqrt_() const {
@@ -469,6 +470,7 @@ template <bool IsMask_, typename Derived_> struct alignas(16)
     DRJIT_INLINE Derived round_()    const { return vrndnq_f64(m);     }
     DRJIT_INLINE Derived floor_()    const { return vrndmq_f64(m);     }
     DRJIT_INLINE Derived ceil_()     const { return vrndpq_f64(m);     }
+    DRJIT_INLINE Derived trunc_()    const { return vrndq_f64(m);      }
 #endif
 
     DRJIT_INLINE Derived rcp_() const {


### PR DESCRIPTION
Closes #63 (the NEON gap that remains after #70/0fc6d5b1 landed).

`round_`/`floor_`/`ceil_` in the NEON packet backend already use the AArch64 rounding intrinsics (`vrndnq`/`vrndmq`/`vrndpq`), but the fourth member of that family, truncation, was missing for both `float32x4` and `float64x2`, so it silently fell back to the generic per-lane scalar loop in `ArrayBaseT`. This adds `trunc_()` using `vrndq_f32`/`vrndq_f64`, the natural counterpart of the existing three, gated behind the same `DRJIT_ARM_64` check the others use. This gap predates the Dr.Jit port — it was already absent in the original Enoki `array_neon.h` this backend was ported from.

**Testing** (Apple Silicon, M-series, native AArch64 NEON):
- Correctness checked against `std::trunc` across positive/negative, fractional, integral, and large-magnitude values for both `float32x4` and `float64x2`.
- Codegen inspected before/after with a standalone harness: at `-O0`, and generally whenever the call isn't fully inlined into a single translation unit, the previous code called out to the generic `ArrayBaseT<...>::trunc_()` loop (real function call, stack traffic, per-lane loop); the new code emits a single `frintz` instruction, matching what `round_`/`floor_`/`ceil_` already produce. At `-O2` in a single translation unit LLVM can sometimes rediscover this vectorization itself, so the difference is most visible in the realistic non-inlined case.

No x86 code paths are touched by this change.